### PR TITLE
feat: Byte array hashsed key generation for attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/peaq-did/Cargo.toml
+++ b/pallets/peaq-did/Cargo.toml
@@ -14,6 +14,9 @@ repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
+[dev-dependencies]
+hex-literal = '0.3.3'
+
 [dependencies.codec]
 default-features = false
 features = ['derive']

--- a/pallets/peaq-did/src/did.rs
+++ b/pallets/peaq-did/src/did.rs
@@ -27,4 +27,5 @@ pub trait Did<AccountId, BlockNumber, Moment> {
 	) -> Result<(), DidError>;
 	fn read(did_address: &AccountId, name: &[u8]) -> Option<Attribute<BlockNumber, Moment>>;
 	fn delete(owner: &AccountId, did_address: &AccountId, name: &[u8]) -> Result<(), DidError>;
+	fn get_hashed_key_for_attr(did_account: &AccountId, name: &[u8]) -> [u8; 32];
 }

--- a/pallets/peaq-did/src/tests.rs
+++ b/pallets/peaq-did/src/tests.rs
@@ -1,5 +1,7 @@
 use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok};
+use hex_literal::hex;
+use crate::did::Did;
 
 #[test]
 fn add_attribute_test() {
@@ -151,5 +153,22 @@ fn remove_attribute_test() {
 			PeaqDID::remove_attribute(Origin::signed(origin), did_account, b"name".to_vec()),
 			Error::<Test>::AttributeNotFound
 		);
+	});
+}
+
+#[test]
+fn hashed_key_correctness_test() {
+	
+	new_test_ext().execute_with(||{
+
+		let did_account = sp_core::sr25519::Public::from_raw(
+			hex!("6031188a7c447201a20c044b5e93a6857683a0186a2e02c799974c94a6e4331d"));
+		let name = b"id";
+		let expected_result = hex!("01621935bef7de2129d77df46f9fc533054dbc82b03df3f4f0ac1ebeab878919");
+
+		assert_eq!(PeaqDID::get_hashed_key_for_attr(
+			&did_account,
+			&name[..]
+		), expected_result)
 	});
 }


### PR DESCRIPTION
Defined a trait method to geneate a key using blake256 over a concatenated array of bytes representing did address and attribute name replacing the existing unit struct based implementation for better compatibility with dApps.