### PR TITLE
Feature/1201472165705029 add more info for app user

### DIFF
--- a/pallets/peaq-transaction/src/lib.rs
+++ b/pallets/peaq-transaction/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod structs;
+
 pub use pallet::*;
 
 #[cfg(test)]
@@ -17,28 +19,7 @@ pub mod pallet {
 	use frame_support::traits::{Currency, ReservableCurrency};
 	use frame_system::pallet_prelude::*;
 	use frame_system::{self as system};
-	use scale_info::TypeInfo;
-
-	// [TODO] Maybe it's worthy to move as a config
-	type CallHash = [u8; 32];
-
-	// It's the same as multi-sig
-	// However, I don't want to import it, so just duplicated
-	#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
-	pub struct Timepoint<BlockNumber> {
-		/// The height of the chain at the point in time.
-		height: BlockNumber,
-		/// The index of the extrinsic at the point in time.
-		index: u32,
-	}
-
-	#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
-	pub struct DeliveredInfo<Balance, Hash, BlockNumber> {
-		pub token_num: Balance,
-		pub tx_hash: Hash,
-		pub time_point: Timepoint<BlockNumber>,
-		pub call_hash: CallHash,
-	}
+	use crate::structs::*;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]

--- a/pallets/peaq-transaction/src/lib.rs
+++ b/pallets/peaq-transaction/src/lib.rs
@@ -32,6 +32,14 @@ pub mod pallet {
 		index: u32,
 	}
 
+	#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+	pub struct DeliveredInfo<Balance, Hash, BlockNumber> {
+		pub token_num: Balance,
+		pub tx_hash: Hash,
+		pub time_point: Timepoint<BlockNumber>,
+		pub call_hash: CallHash,
+	}
+
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -64,10 +72,8 @@ pub mod pallet {
 		ServiceDelivered {
 			provider: T::AccountId,
 			consumer: T::AccountId,
-			token_num: BalanceOf<T>,
-			tx_hash: T::Hash,
-			time_point: Timepoint<T::BlockNumber>,
-			call_hash: CallHash,
+			refund_info: DeliveredInfo<BalanceOf<T>, T::Hash, T::BlockNumber>,
+			spent_info: DeliveredInfo<BalanceOf<T>, T::Hash, T::BlockNumber>,
 		},
 	}
 
@@ -103,10 +109,8 @@ pub mod pallet {
 		pub fn service_delivered(
 			origin: OriginFor<T>,
 			consumer: T::AccountId,
-			token_num: BalanceOf<T>,
-			tx_hash: T::Hash,
-			time_point: Timepoint<T::BlockNumber>,
-			call_hash: CallHash) -> DispatchResult {
+			refund_info: DeliveredInfo<BalanceOf<T>, T::Hash, T::BlockNumber>,
+			spent_info: DeliveredInfo<BalanceOf<T>, T::Hash, T::BlockNumber>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			// [TODO] We can check wehther the tx is the same as the timepoint
@@ -115,10 +119,8 @@ pub mod pallet {
 			Self::deposit_event(Event::ServiceDelivered{
 				provider: who,
 				consumer,
-				token_num,
-				tx_hash,
-				time_point,
-				call_hash,
+				refund_info,
+				spent_info,
 			});
 			// Return a successful DispatchResultWithPostInfo
 			Ok(())

--- a/pallets/peaq-transaction/src/structs.rs
+++ b/pallets/peaq-transaction/src/structs.rs
@@ -1,0 +1,21 @@
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_core::RuntimeDebug;
+
+type CallHash = [u8; 32];
+
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+pub struct Timepoint<BlockNumber> {
+	/// The height of the chain at the point in time.
+	pub height: BlockNumber,
+	/// The index of the extrinsic at the point in time.
+	pub index: u32,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+pub struct DeliveredInfo<Balance, Hash, BlockNumber> {
+	pub token_num: Balance,
+	pub tx_hash: Hash,
+	pub time_point: Timepoint<BlockNumber>,
+	pub call_hash: CallHash,
+}

--- a/pallets/peaq-transaction/src/tests.rs
+++ b/pallets/peaq-transaction/src/tests.rs
@@ -2,8 +2,9 @@ use crate as peaq_transaction;
 use crate::mock::*;
 use frame_support::assert_ok;
 use sp_io::hashing::blake2_256;
+use crate::structs::*;
 
-fn now() -> peaq_transaction::Timepoint<u64> {
+fn now() -> Timepoint<u64> {
 	TransactionModule::now()
 }
 
@@ -26,13 +27,13 @@ fn service_requested_success() {
 #[test]
 fn service_delivered_success() {
 	new_test_ext().execute_with(|| {
-		let refund_info = peaq_transaction::DeliveredInfo {
+		let refund_info = DeliveredInfo {
 			token_num: 25,
 			tx_hash: blake2_256(b"refund tx hash").into(),
 			time_point: now(),
 			call_hash: blake2_256(b"refund call hash"),
 		};
-		let spent_info = peaq_transaction::DeliveredInfo {
+		let spent_info = DeliveredInfo {
 			token_num: 20,
 			tx_hash: blake2_256(b"spent tx hash").into(),
 			time_point: now(),

--- a/pallets/peaq-transaction/src/tests.rs
+++ b/pallets/peaq-transaction/src/tests.rs
@@ -26,21 +26,28 @@ fn service_requested_success() {
 #[test]
 fn service_delivered_success() {
 	new_test_ext().execute_with(|| {
-		let hash = blake2_256(b"call hash");
-		let tx_hash = blake2_256(b"tx hash").into();
-		let timepoint = now();
+		let refund_info = peaq_transaction::DeliveredInfo {
+			token_num: 25,
+			tx_hash: blake2_256(b"refund tx hash").into(),
+			time_point: now(),
+			call_hash: blake2_256(b"refund call hash"),
+		};
+		let spent_info = peaq_transaction::DeliveredInfo {
+			token_num: 20,
+			tx_hash: blake2_256(b"spent tx hash").into(),
+			time_point: now(),
+			call_hash: blake2_256(b"spent call hash"),
+		};
 
 		assert_ok!(TransactionModule::service_delivered(
-			Origin::signed(1), 2, 42, tx_hash, timepoint, hash));
+			Origin::signed(1), 2, refund_info.clone(), spent_info.clone()));
 
 		System::assert_last_event(
 			peaq_transaction::Event::ServiceDelivered {
 				provider: 1,
 				consumer: 2,
-				token_num: 42,
-				tx_hash: tx_hash,
-				time_point: timepoint,
-				call_hash: hash,
+				refund_info: refund_info.clone(),
+				spent_info: spent_info.clone(),
 			}
 			.into(),
 		);


### PR DESCRIPTION
We change service_delivered's argument and event in the pull request because the app user needs to know the refund_info/spent_info. After knowing this information, he can send the two approve_as_multi extrinsic to approve the refund/spend for transferring tokens.

Because we don't want to send two extrinsic, so modifying the service_delivered's argument and the event is a better solution.