### PR TITLE
Feature/1201590612941083 evm integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,6 +2862,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4345,6 +4348,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-precompile-blake2"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-precompile-bn128"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "sp-core",
+ "sp-io",
+ "substrate-bn",
+]
+
+[[package]]
+name = "pallet-evm-precompile-dispatch"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "pallet-evm",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
 source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
@@ -4789,6 +4826,9 @@ dependencies = [
  "pallet-dynamic-fee",
  "pallet-ethereum",
  "pallet-evm",
+ "pallet-evm-precompile-blake2",
+ "pallet-evm-precompile-bn128",
+ "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
@@ -7707,6 +7747,19 @@ dependencies = [
  "schnorrkel",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.4",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,17 +637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -3386,16 +3375,14 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.28.2"
+version = "6.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5eb01f2fb869e2a4d15bff6a2977b3df5c42fa74daacc109f0d09a96398a188"
+checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
 dependencies = [
  "bindgen",
- "bzip2-sys",
  "cc",
  "glob",
  "libc",
- "libz-sys",
 ]
 
 [[package]]
@@ -8022,9 +8009,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.8",
@@ -8034,9 +8021,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8045,11 +8032,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -8338,6 +8326,12 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 
 [[package]]
 name = "frame-benchmarking"
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "num",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
 dependencies = [
  "fp-evm",
  "ripemd160",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -668,7 +668,7 @@ checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.4",
+ "semver 1.0.5",
  "serde",
  "serde_json",
 ]
@@ -810,9 +810,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.11.1"
-source = "git+https://github.com/purestake/ethereum?branch=tgm-0.11.1-typeinfo-patch#42ee428264e27773da5e93f264f0aa7daf1a8a7f"
+source = "git+https://github.com/peaqnetwork/ethereum?branch=tgm-0.11.1-typeinfo-patch#42ee428264e27773da5e93f264f0aa7daf1a8a7f"
 dependencies = [
  "bytes 1.1.0",
  "ethereum-types",
@@ -1442,7 +1442,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
 ]
 
 [[package]]
@@ -1469,14 +1469,14 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "async-trait",
  "derive_more",
  "fc-db",
  "fp-consensus",
  "fp-rpc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -1511,13 +1511,13 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fc-consensus",
  "fc-db",
  "fp-consensus",
  "fp-rpc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "sc-client-api",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1541,7 +1541,7 @@ dependencies = [
  "fp-evm",
  "fp-rpc",
  "fp-storage",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "file-per-thread-logger"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
  "env_logger",
  "log",
@@ -1616,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
 dependencies = [
  "either",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "num-traits",
@@ -1665,7 +1665,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -1743,12 +1743,12 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1885,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "log",
@@ -1902,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1975,9 +1975,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1990,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2000,15 +2000,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2061,15 +2061,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-timer"
@@ -2085,9 +2085,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -2383,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -2395,12 +2395,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error 1.2.3",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2493,7 +2490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
 dependencies = [
  "async-io",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -2531,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2575,7 +2572,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 2.0.2",
 ]
 
@@ -2668,7 +2665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -2683,7 +2680,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-executor",
  "futures-util",
  "log",
@@ -2698,7 +2695,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-client-transports",
 ]
 
@@ -2720,7 +2717,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2736,7 +2733,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -2751,7 +2748,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -2767,7 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -2784,7 +2781,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -2900,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libp2p"
@@ -2912,7 +2909,7 @@ checksum = "3bec54343492ba5940a6c555e512c6721139835d28c59bc22febece72dfd0d9d"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "libp2p-core",
  "libp2p-deflate",
@@ -2947,17 +2944,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef22d9bba1e8bcb7ec300073e6802943fe8abb8190431842262b5f1c30abba1"
+checksum = "86aad7d54df283db817becded03e611137698a6509d4237a96881976a162340c"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
+ "instant",
  "lazy_static",
  "libsecp256k1 0.7.0",
  "log",
@@ -2986,7 +2984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51a800adb195f33de63f4b17b63fe64cfc23bf2c6a0d3d0d5321328664e65197"
 dependencies = [
  "flate2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
 ]
 
@@ -2997,7 +2995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb8f89d15cb6e3c5bc22afff7513b11bab7856f2872d3cfba86f7f63a06bc498"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "log",
  "smallvec",
@@ -3012,7 +3010,7 @@ checksum = "aab3d7210901ea51b7bae2b581aa34521797af8c4ec738c980bda4a06434067f"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3033,7 +3031,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
@@ -3054,7 +3052,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca1275574183f288ff8b72d535d5ffa5ea9292ef7829af8b47dcb197c7b0dcd"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3076,7 +3074,7 @@ dependencies = [
  "bytes 1.1.0",
  "either",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3100,7 +3098,7 @@ dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.19",
+ "futures 0.3.21",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -3134,7 +3132,7 @@ checksum = "7f2cd64ef597f40e14bfce0497f50ecb63dd6d201c61796daeb4227078834fbf"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -3152,7 +3150,7 @@ checksum = "a8772c7a99088221bb7ca9c5c0574bf55046a7ab4c319f3619b275f28c8fb87a"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -3172,7 +3170,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80ef7b0ec5cf06530d9eb6cf59ae49d46a2c45663bde31c25a12f682664adbcf"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3189,7 +3187,7 @@ checksum = "5fba1a6ff33e4a274c89a3b1d78b9f34f32af13265cc5c46c16938262d4e945a"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "log",
  "prost",
@@ -3204,7 +3202,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "pin-project 1.0.10",
  "rand 0.7.3",
@@ -3220,7 +3218,7 @@ checksum = "2852b61c90fa8ce3c8fcc2aba76e6cefc20d648f9df29157d6b3a916278ef3e3"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "libp2p-core",
  "libp2p-swarm",
@@ -3243,7 +3241,7 @@ checksum = "14a6d2b9e7677eff61dc3d2854876aaf3976d84a01ef6664b610c77a0c9407c5"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bimap",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3265,7 +3263,7 @@ checksum = "a877a4ced6d46bf84677e1974e8cf61fb434af73b2e96fb48d6cb6223a4634d8"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3283,7 +3281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f5184a508f223bc100a12665517773fb8730e9f36fc09eefb670bf01b107ae9"
 dependencies = [
  "either",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3309,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7399c5b6361ef525d41c11fcf51635724f832baf5819b30d3d873eabb4fbae4b"
 dependencies = [
  "async-io",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "if-watch",
  "ipnet",
@@ -3326,7 +3324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7563e46218165dfd60f64b96f7ce84590d75f53ecbdc74a7dd01450dc5973"
 dependencies = [
  "async-std",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "log",
 ]
@@ -3337,7 +3335,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1008a302b73c5020251f9708c653f5ed08368e530e247cc9cd2f109ff30042cf"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3352,7 +3350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e12df82d1ed64969371a9e65ea92b91064658604cc2576c2757f18ead9a1cf"
 dependencies = [
  "either",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-rustls",
  "libp2p-core",
  "log",
@@ -3369,7 +3367,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7362abb8867d7187e7e93df17f460d554c997fc5c8ac57dc1259057f6889af"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p-core",
  "parking_lot",
  "thiserror",
@@ -3840,7 +3838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "pin-project 1.0.10",
  "smallvec",
@@ -4129,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4145,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4160,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4175,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4190,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -4218,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -4232,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4242,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4261,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4274,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -4292,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4322,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4350,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4360,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4371,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -4384,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "num",
@@ -4395,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4406,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#7e4fd790f7592b77fab0b9007860d98335b2f133"
+source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.13#a9ebeb8c73298dbd2f676d2a4efd29faf43b9fd2"
 dependencies = [
  "fp-evm",
  "ripemd160",
@@ -4417,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4440,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4454,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4468,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4489,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4503,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4521,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4538,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4555,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4620,7 +4618,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libc",
  "log",
  "rand 0.7.3",
@@ -4759,7 +4757,7 @@ dependencies = [
  "fp-rpc",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex-literal",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -4862,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-did"
 version = "0.0.1"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=feature/1201590612941083_evm_integration#00e387f16199e90b8aab7d8106fe7d012f330783"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=feature/1201590612941083_evm_integration#b2b00f3bf23526e020554c62ef18a0e0ee9c6c1c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4879,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-transaction"
 version = "0.0.1"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?branch=feature/1201590612941083_evm_integration#d57ca681f5c7165432dffadaf1970bf9293ec798"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?branch=feature/1201590612941083_evm_integration#bc7549402f8bf82611c4fac7dd2aeb0eb54671bf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5646,7 +5644,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.5",
 ]
 
 [[package]]
@@ -5680,7 +5678,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "pin-project 0.4.29",
  "static_assertions",
 ]
@@ -5721,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "sp-core",
@@ -5732,9 +5730,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5755,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5771,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.2",
@@ -5788,7 +5786,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5799,11 +5797,11 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "chrono",
  "fdlimit",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex",
  "libp2p",
  "log",
@@ -5837,10 +5835,10 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hash-db",
  "log",
  "parity-scale-codec",
@@ -5865,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5890,10 +5888,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5914,11 +5912,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -5943,12 +5941,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
  "fork-tree",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "merlin",
  "num-bigint 0.2.6",
@@ -5986,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5999,12 +5997,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "assert_matches",
  "async-trait",
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6033,10 +6031,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -6059,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "lazy_static",
  "libsecp256k1 0.7.0",
@@ -6086,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "derive_more",
  "environmental",
@@ -6104,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6120,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -6138,14 +6136,14 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -6175,10 +6173,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "ansi_term",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "parity-util-mem",
@@ -6192,7 +6190,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6207,7 +6205,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6219,7 +6217,7 @@ dependencies = [
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
@@ -6258,9 +6256,9 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6274,11 +6272,11 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "hex",
  "hyper",
@@ -6302,9 +6300,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p",
  "log",
  "sc-utils",
@@ -6315,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6324,9 +6322,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -6355,9 +6353,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6380,9 +6378,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
@@ -6397,12 +6395,12 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -6461,7 +6459,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6475,10 +6473,10 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "chrono",
- "futures 0.3.19",
+ "futures 0.3.21",
  "libp2p",
  "log",
  "parking_lot",
@@ -6493,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "ansi_term",
  "atty",
@@ -6524,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -6535,9 +6533,9 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "intervalier",
  "linked-hash-map",
  "log",
@@ -6562,10 +6560,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "serde",
  "sp-blockchain",
@@ -6576,9 +6574,9 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "lazy_static",
  "prometheus",
@@ -6671,9 +6669,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6684,9 +6682,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6721,9 +6719,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 dependencies = [
  "serde",
 ]
@@ -6967,7 +6965,7 @@ dependencies = [
  "base64",
  "bytes 1.1.0",
  "flate2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "httparse",
  "log",
  "rand 0.8.4",
@@ -6977,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "log",
@@ -6994,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.1.0",
@@ -7006,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7019,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7034,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7046,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7058,9 +7056,9 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "lru 0.7.2",
  "parity-scale-codec",
@@ -7076,10 +7074,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -7095,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7113,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "merlin",
@@ -7136,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7148,7 +7146,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7160,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "base58",
  "bitflags",
@@ -7168,7 +7166,7 @@ dependencies = [
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -7208,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -7221,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7232,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "kvdb",
  "parking_lot",
@@ -7241,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7251,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7262,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7280,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7294,9 +7292,9 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "hash-db",
  "libsecp256k1 0.7.0",
  "log",
@@ -7318,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7329,11 +7327,11 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "merlin",
  "parity-scale-codec",
  "parking_lot",
@@ -7346,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "zstd",
 ]
@@ -7354,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7364,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -7374,7 +7372,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7384,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7406,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7423,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -7435,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7449,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "serde",
  "serde_json",
@@ -7458,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7472,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7483,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "log",
@@ -7506,12 +7504,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7524,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "sp-core",
@@ -7537,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -7553,7 +7551,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -7565,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7574,7 +7572,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "log",
@@ -7590,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7605,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7621,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -7632,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7765,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "platforms",
 ]
@@ -7773,10 +7771,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7795,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7809,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+source = "git+https://github.com/peaqnetwork/substrate?branch=peaq-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -8116,9 +8114,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -8259,9 +8257,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b413ebfe8c2c74a69ff124699dd156a7fa41cb1d09ba6df94aa2f2b0a4a3a"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8295,9 +8293,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -8542,7 +8540,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -8879,7 +8877,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "nohash-hasher",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
  "once_cell",
  "version_check",
 ]
@@ -93,15 +93,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -111,15 +102,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.48"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "approx"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
@@ -156,6 +147,12 @@ name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
@@ -212,7 +209,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.2",
+ "socket2 0.4.4",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -274,7 +271,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -282,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "async-std-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4e2c3da14d8ad45acb1e3191db7a918e9505b6f155b218e70a7c9a1a48c638"
+checksum = "dbf3e776afdf3a2477ef4854b85ba0dff3bd85792f685fb3c68948b4d304e4f0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -296,15 +293,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -321,7 +318,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -334,7 +331,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -364,6 +361,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,16 +380,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line 0.17.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.27.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -392,21 +401,21 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base58"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
 
 [[package]]
 name = "bincode"
@@ -419,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -444,24 +453,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium 0.5.3",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -543,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -601,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
@@ -635,27 +632,32 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cache-padded"
-version = "1.1.1"
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -671,14 +673,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser 0.10.2",
+ "semver 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -768,7 +769,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -779,31 +780,22 @@ checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.7.2",
+ "libloading 0.7.3",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -845,9 +837,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931ab2a3e6330a07900b8e7ca4e106cdcbb93f2b9a52df55e54ee53d8305b55d"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -872,18 +864,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "cc0cb7df82c8cf8f2e6a8dd394a0932a71369c160cc9b027dca414fced242513"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "fe4463c15fa42eee909e61e5eac4866b7c6d22d0d8c621e57a0c5380753bfa8c"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -892,16 +884,15 @@ dependencies = [
  "gimli 0.25.0",
  "log",
  "regalloc",
- "serde",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "793f6a94a053a55404ea16e1700202a88101672b8cd6b4df63e13cde950852bf"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -909,27 +900,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
-dependencies = [
- "serde",
-]
+checksum = "44aa1846df275bce5eb30379d65964c7afc63c05a117076e62a119c25fe174be"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "a3a45d8d6318bf8fc518154d9298eab2a8154ec068a8885ff113f6db8d69bb3a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "e07339bd461766deb7605169de039e01954768ff730fa1254e149001884a8525"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -939,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c04d1fe6a5abb5bb0edc78baa8ef238370fb8e389cc88b6d153f7c3e9680425"
+checksum = "03e2fca76ff57e0532936a71e3fc267eae6a19a86656716479c66e7f912e3d7b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -950,35 +938,34 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d260ad44f6fd2c91f7f5097191a2a9e3edcbb36df1fb787b600dad5ea148ec"
+checksum = "1f46fec547a1f8a32c54ea61c28be4f4ad234ad95342b718a9a9adcaadb0c778"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
  "log",
- "serde",
  "smallvec",
- "thiserror",
  "wasmparser",
+ "wasmtime-types",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -997,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1010,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1040,7 +1027,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle 2.4.1",
 ]
 
@@ -1050,7 +1037,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle 2.4.1",
 ]
 
@@ -1147,14 +1134,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -1173,14 +1160,14 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
 name = "directories"
-version = "3.0.2"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
  "dirs-sys",
 ]
@@ -1234,6 +1221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,7 +1272,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -1321,15 +1314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,10 +1335,117 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
+name = "ethbloom"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum"
+version = "0.11.1"
+source = "git+https://github.com/purestake/ethereum?branch=tgm-0.11.1-typeinfo-patch#42ee428264e27773da5e93f264f0aa7daf1a8a7f"
+dependencies = [
+ "bytes 1.1.0",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec",
+ "rlp",
+ "rlp-derive",
+ "scale-info",
+ "serde",
+ "sha3 0.9.1",
+ "triehash",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "evm"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408ffdd509e16de15ea9b51f5333748f6086601f29d445d2ba53dd7e95565574"
+dependencies = [
+ "auto_impl",
+ "environmental",
+ "ethereum",
+ "evm-core",
+ "evm-gasometer",
+ "evm-runtime",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfe4f2a56c4c05a8107b8596380e2332fc2019ffcf56b8f2d01971393a30c4d"
+dependencies = [
+ "funty",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c446679607eacac4e8c8738e20c97ea9b3c86eddd8b43666744b05f416037bd9"
+dependencies = [
+ "environmental",
+ "evm-core",
+ "evm-runtime",
+ "primitive-types",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e8434ac6e850a8a4bc09a19406264582d1940913b2920be2af948f4ffc49b"
+dependencies = [
+ "environmental",
+ "evm-core",
+ "primitive-types",
+ "sha3 0.8.2",
+]
 
 [[package]]
 name = "exit-future"
@@ -1362,7 +1453,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
 ]
 
 [[package]]
@@ -1379,11 +1470,135 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fc-consensus"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "fc-db",
+ "fp-consensus",
+ "fp-rpc",
+ "futures 0.3.19",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "fc-db"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-storage",
+ "kvdb",
+ "kvdb-rocksdb",
+ "pallet-ethereum",
+ "parity-scale-codec",
+ "parking_lot",
+ "sp-core",
+ "sp-database",
+ "sp-runtime",
+]
+
+[[package]]
+name = "fc-mapping-sync"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fc-consensus",
+ "fc-db",
+ "fp-consensus",
+ "fp-rpc",
+ "futures 0.3.19",
+ "futures-timer 3.0.2",
+ "log",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "fc-rpc"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "evm",
+ "fc-consensus",
+ "fc-db",
+ "fc-rpc-core",
+ "fp-consensus",
+ "fp-evm",
+ "fp-rpc",
+ "fp-storage",
+ "futures 0.3.19",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-pubsub",
+ "libsecp256k1 0.3.5",
+ "log",
+ "lru 0.6.6",
+ "pallet-ethereum",
+ "pallet-evm",
+ "parity-scale-codec",
+ "parking_lot",
+ "rand 0.7.3",
+ "rlp",
+ "rustc-hex",
+ "sc-client-api",
+ "sc-network",
+ "sc-rpc",
+ "sc-service",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "sha3 0.8.2",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-io",
+ "sp-runtime",
+ "sp-storage",
+ "sp-transaction-pool",
+]
+
+[[package]]
+name = "fc-rpc-core"
+version = "1.1.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-pubsub",
+ "rlp",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "sha3 0.8.2",
 ]
 
 [[package]]
@@ -1412,12 +1627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
 dependencies = [
  "either",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "scale-info",
 ]
 
@@ -1435,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
@@ -1461,7 +1676,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1477,9 +1692,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "fp-consensus"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "parity-scale-codec",
+ "rlp",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "fp-evm"
+version = "3.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "evm",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-std",
+]
+
+[[package]]
+name = "fp-rpc"
+version = "3.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fp-evm",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "fp-self-contained"
+version = "1.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "frame-support",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "fp-storage"
+version = "2.0.0"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+
+[[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1499,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1525,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1553,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1568,6 +1848,7 @@ dependencies = [
  "smallvec",
  "sp-arithmetic",
  "sp-core",
+ "sp-core-hashing-proc-macro",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -1575,12 +1856,13 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
+ "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1592,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -1604,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1614,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "log",
@@ -1631,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1646,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1704,9 +1986,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1719,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1729,15 +2011,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1747,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-lite"
@@ -1762,15 +2044,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1790,15 +2072,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-timer"
@@ -1814,9 +2096,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1826,7 +2108,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "pin-utils",
  "slab",
 ]
@@ -1842,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -1865,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1922,22 +2204,40 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
 dependencies = [
  "futures-channel",
  "futures-core",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "25546a65e5cf1f471f3438796fc634650b31d7fcde01d444c309aeb28b92e3a8"
 dependencies = [
  "log",
  "pest",
@@ -2055,7 +2355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "hmac 0.8.1",
 ]
 
@@ -2072,13 +2372,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -2089,7 +2389,7 @@ checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -2115,21 +2415,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
- "pin-project-lite 0.2.7",
- "socket2 0.4.2",
+ "itoa 0.4.8",
+ "pin-project-lite 0.2.8",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2203,7 +2504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
 dependencies = [
  "async-io",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -2219,6 +2520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -2243,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2276,8 +2586,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 2.0.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
+dependencies = [
+ "rustc_version 0.4.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2315,9 +2635,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -2327,6 +2647,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -2339,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2353,7 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -2368,7 +2694,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-executor",
  "futures-util",
  "log",
@@ -2383,7 +2709,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-client-transports",
 ]
 
@@ -2405,13 +2731,13 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
  "net2",
- "parking_lot 0.11.2",
+ "parking_lot",
  "unicase",
 ]
 
@@ -2421,12 +2747,12 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
  "parity-tokio-ipc",
- "parking_lot 0.11.2",
+ "parking_lot",
  "tower-service",
 ]
 
@@ -2436,11 +2762,11 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "lazy_static",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.7.3",
  "serde",
 ]
@@ -2452,7 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -2469,12 +2795,12 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
  "parity-ws",
- "parking_lot 0.11.2",
+ "parking_lot",
  "slab",
 ]
 
@@ -2521,7 +2847,7 @@ checksum = "c3b6b85fc643f5acd0bffb2cc8a6d150209379267af0d41db72170021841f9f5"
 dependencies = [
  "kvdb",
  "parity-util-mem",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2536,7 +2862,7 @@ dependencies = [
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
- "parking_lot 0.11.2",
+ "parking_lot",
  "regex",
  "rocksdb",
  "smallvec",
@@ -2556,9 +2882,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libloading"
@@ -2572,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2588,13 +2914,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
+checksum = "3bec54343492ba5940a6c555e512c6721139835d28c59bc22febece72dfd0d9d"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "libp2p-deflate",
@@ -2604,12 +2930,14 @@ dependencies = [
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
+ "libp2p-metrics",
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-pnet",
  "libp2p-relay",
+ "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-swarm-derive",
@@ -2619,39 +2947,39 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
- "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "parking_lot",
+ "pin-project 1.0.10",
  "smallvec",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9b4abdeaa420593a297c8592f63fad4234f4b88dc9343b8fd8e736c35faa59"
+checksum = "bef22d9bba1e8bcb7ec300073e6802943fe8abb8190431842262b5f1c30abba1"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1 0.7.0",
  "log",
  "multiaddr",
  "multihash 0.14.0",
  "multistream-select",
- "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "parking_lot",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand 0.8.4",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.1",
@@ -2661,23 +2989,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
+checksum = "51a800adb195f33de63f4b17b63fe64cfc23bf2c6a0d3d0d5321328664e65197"
 dependencies = [
  "flate2",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
+checksum = "bb8f89d15cb6e3c5bc22afff7513b11bab7856f2872d3cfba86f7f63a06bc498"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "smallvec",
@@ -2686,13 +3014,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
+checksum = "aab3d7210901ea51b7bae2b581aa34521797af8c4ec738c980bda4a06434067f"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2704,16 +3032,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cc48709bcbc3a3321f08a73560b4bbb4166a7d56f6fdb615bc775f4f91058e"
+checksum = "dfeead619eb5dac46e65acc78c535a60aaec803d1428cca6407c3a4fc74d698d"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
@@ -2722,7 +3050,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "unsigned-varint 0.7.1",
  "wasm-timer",
@@ -2730,14 +3058,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
+checksum = "cca1275574183f288ff8b72d535d5ffa5ea9292ef7829af8b47dcb197c7b0dcd"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
+ "lru 0.6.6",
  "prost",
  "prost-build",
  "smallvec",
@@ -2746,23 +3075,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ed78489c87924235665a0ab345b298ee34dff0f7ad62c0ba6608b2144fb75e"
+checksum = "a2297dc0ca285f3a09d1368bde02449e539b46f94d32d53233f53f6625bcd3ba"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
  "either",
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.1",
@@ -2772,14 +3101,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29e6cbc2a24b8471b6567e580a0e8e7b70a6d0f0ea2be0844d1e842d7d4fa33"
+checksum = "14c864b64bdc8a84ff3910a0df88e6535f256191a450870f1e7e10cbf8e64d45"
 dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.18",
+ "futures 0.3.19",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -2787,23 +3116,37 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.2",
+ "socket2 0.4.4",
  "void",
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.29.0"
+name = "libp2p-metrics"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
+checksum = "4af432fcdd2f8ba4579b846489f8f0812cfd738ced2c0af39df9b1c48bbb6ab2"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-swarm",
+ "open-metrics-client",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2cd64ef597f40e14bfce0497f50ecb63dd6d201c61796daeb4227078834fbf"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.1",
@@ -2811,20 +3154,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
+checksum = "a8772c7a99088221bb7ca9c5c0574bf55046a7ab4c319f3619b275f28c8fb87a"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
  "rand 0.8.4",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -2833,11 +3176,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
+checksum = "80ef7b0ec5cf06530d9eb6cf59ae49d46a2c45663bde31c25a12f682664adbcf"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2848,13 +3191,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
+checksum = "5fba1a6ff33e4a274c89a3b1d78b9f34f32af13265cc5c46c16938262d4e945a"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "prost",
@@ -2865,32 +3208,32 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
+checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "salsa20",
- "sha3",
+ "sha3 0.9.1",
 ]
 
 [[package]]
 name = "libp2p-relay"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
+checksum = "2852b61c90fa8ce3c8fcc2aba76e6cefc20d648f9df29157d6b3a916278ef3e3"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2901,19 +3244,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-request-response"
-version = "0.12.0"
+name = "libp2p-rendezvous"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
+checksum = "14a6d2b9e7677eff61dc3d2854876aaf3976d84a01ef6664b610c77a0c9407c5"
 dependencies = [
- "async-trait",
- "bytes 1.1.0",
- "futures 0.3.18",
+ "asynchronous-codec 0.6.0",
+ "bimap",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru",
- "minicbor",
+ "prost",
+ "prost-build",
+ "rand 0.8.4",
+ "sha2 0.9.9",
+ "thiserror",
+ "unsigned-varint 0.7.1",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a877a4ced6d46bf84677e1974e8cf61fb434af73b2e96fb48d6cb6223a4634d8"
+dependencies = [
+ "async-trait",
+ "bytes 1.1.0",
+ "futures 0.3.19",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "lru 0.7.2",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.1",
@@ -2922,12 +3286,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
+checksum = "3f5184a508f223bc100a12665517773fb8730e9f36fc09eefb670bf01b107ae9"
 dependencies = [
  "either",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -2938,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
+checksum = "072c290f727d39bdc4e9d6d1c847978693d25a673bd757813681e33e5f6c00c2"
 dependencies = [
  "quote",
  "syn",
@@ -2948,40 +3312,40 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
+checksum = "7399c5b6361ef525d41c11fcf51635724f832baf5819b30d3d873eabb4fbae4b"
 dependencies = [
  "async-io",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "if-watch",
  "ipnet",
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.2",
+ "socket2 0.4.4",
 ]
 
 [[package]]
 name = "libp2p-uds"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
+checksum = "b8b7563e46218165dfd60f64b96f7ce84590d75f53ecbdc74a7dd01450dc5973"
 dependencies = [
  "async-std",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
+checksum = "1008a302b73c5020251f9708c653f5ed08368e530e247cc9cd2f109ff30042cf"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -2991,12 +3355,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
+checksum = "22e12df82d1ed64969371a9e65ea92b91064658604cc2576c2757f18ead9a1cf"
 dependencies = [
  "either",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-rustls",
  "libp2p-core",
  "log",
@@ -3009,27 +3373,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
+checksum = "4e7362abb8867d7187e7e93df17f460d554c997fc5c8ac57dc1259057f6889af"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p-core",
- "parking_lot 0.11.2",
+ "parking_lot",
  "thiserror",
  "yamux",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
+checksum = "e5eb01f2fb869e2a4d15bff6a2977b3df5c42fa74daacc109f0d09a96398a188"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
 ]
 
 [[package]]
@@ -3050,47 +3416,28 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
 dependencies = [
  "arrayref",
- "base64 0.12.3",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg 0.3.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde",
- "sha2 0.9.8",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "typenum",
 ]
 
 [[package]]
 name = "libsecp256k1-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
@@ -3099,18 +3446,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
  "libsecp256k1-core",
 ]
 
 [[package]]
 name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
@@ -3152,19 +3499,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.3.4"
+name = "linux-raw-sys"
+version = "0.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
+checksum = "687387ff42ec7ea4f2149035a5675fedb675d26f98db90a1846ac63d3addb5f5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -3184,6 +3528,15 @@ name = "lru"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
 ]
@@ -3278,10 +3631,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.4"
+name = "memmap2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -3316,24 +3678,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "minicbor"
-version = "0.8.1"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51aa5bb0ca22415daca596a227b507f880ad1b2318a87fa9325312a5d285ca0d"
-dependencies = [
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54999f917cd092b13904737e26631aa2b2b88d625db68e4bab461dcd8006c788"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3455,10 +3803,10 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "multihash-derive",
- "sha2 0.9.8",
- "sha3",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
  "unsigned-varint 0.5.1",
 ]
 
@@ -3469,9 +3817,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "multihash-derive",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "unsigned-varint 0.7.1",
 ]
 
@@ -3502,9 +3850,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "smallvec",
  "unsigned-varint 0.7.1",
 ]
@@ -3572,13 +3920,12 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec 0.19.6",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -3592,10 +3939,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.0",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3622,13 +3994,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -3640,6 +4023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -3656,23 +4040,33 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "object"
-version = "0.26.2"
+name = "num_enum"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "720d3ea1055e4e4574c0c0b0f8c3fd4f24c4cdaf465948206dea090b57b526ad"
 dependencies = [
- "crc32fast",
- "indexmap",
- "memchr",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3681,14 +4075,16 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
+ "crc32fast",
+ "indexmap",
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -3703,10 +4099,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.4"
+name = "open-metrics-client"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "7337d80c23c2d8b1349563981bc4fb531220733743ba8115454a67b181173f0d"
+dependencies = [
+ "dtoa",
+ "itoa 0.4.8",
+ "open-metrics-client-derive-text-encode",
+ "owning_ref",
+]
+
+[[package]]
+name = "open-metrics-client-derive-text-encode"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c83b586f00268c619c1cb3340ec1a6f59dd9ba1d9833a273a68e6d5cd8ffc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "owning_ref"
@@ -3720,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3736,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3751,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3764,22 +4183,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-base-fee"
+version = "1.0.0"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-evm",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.7.0",
  "log",
  "pallet-contracts-primitives",
  "pallet-contracts-proc-macro",
  "parity-scale-codec",
  "pwasm-utils",
- "rand 0.7.3",
- "rand_pcg",
+ "rand 0.8.4",
+ "rand_pcg 0.3.1",
  "scale-info",
  "serde",
  "smallvec",
@@ -3794,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -3808,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3818,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3837,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -3848,9 +4282,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-dynamic-fee"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "async-trait",
+ "frame-support",
+ "frame-system",
+ "pallet-evm",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-ethereum"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "evm",
+ "fp-consensus",
+ "fp-evm",
+ "fp-rpc",
+ "fp-self-contained",
+ "fp-storage",
+ "frame-support",
+ "frame-system",
+ "num_enum",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "rlp",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-evm"
+version = "6.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
+ "fp-evm",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "log",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-evm-precompile-modexp"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "num",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-precompile-sha3fips"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "sp-core",
+ "sp-io",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "pallet-evm-precompile-simple"
+version = "2.0.0-dev"
+source = "git+https://github.com/purestake/frontier?rev=7927173a7#7927173a7b2e0973f6103414712f24c6fec1625f"
+dependencies = [
+ "fp-evm",
+ "ripemd160",
+ "sp-core",
+ "sp-io",
+]
+
+[[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3873,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3887,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3901,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3922,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3936,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3954,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3971,7 +4514,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3988,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -3998,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a95abf24f1097c6e3181abbbbfc3630b3b5e681470940f719b69acb4911c7f"
+checksum = "68de01cff53da5574397233383dd7f5c15ee958c348245765ea8cb09f2571e6b"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
@@ -4009,8 +4552,8 @@ dependencies = [
  "libc",
  "log",
  "lz4",
- "memmap2",
- "parking_lot 0.11.2",
+ "memmap2 0.2.3",
+ "parking_lot",
  "rand 0.8.4",
  "snap",
 ]
@@ -4022,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.2",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -4053,7 +4596,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "libc",
  "log",
  "rand 0.7.3",
@@ -4068,10 +4611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
+ "ethereum-types",
  "hashbrown",
  "impl-trait-for-tuples",
+ "lru 0.6.6",
  "parity-util-mem-derive",
- "parking_lot 0.11.2",
+ "parking_lot",
  "primitive-types",
  "smallvec",
  "winapi 0.3.9",
@@ -4129,37 +4674,13 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4171,7 +4692,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -4202,14 +4723,29 @@ dependencies = [
 
 [[package]]
 name = "peaq-node"
-version = "3.0.0-monthly-2021-10"
+version = "3.0.0-polkadot-v0.9.13"
 dependencies = [
+ "async-trait",
+ "fc-consensus",
+ "fc-db",
+ "fc-mapping-sync",
+ "fc-rpc",
+ "fc-rpc-core",
+ "fp-consensus",
+ "fp-rpc",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "futures 0.3.19",
  "hex-literal",
  "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "log",
+ "pallet-base-fee",
  "pallet-contracts",
  "pallet-contracts-rpc",
+ "pallet-dynamic-fee",
+ "pallet-ethereum",
+ "pallet-evm",
  "pallet-transaction-payment-rpc",
  "peaq-node-runtime",
  "sc-basic-authorship",
@@ -4217,6 +4753,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-aura",
+ "sc-consensus-manual-seal",
  "sc-executor",
  "sc-finality-grandpa",
  "sc-keystore",
@@ -4234,6 +4771,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-finality-grandpa",
+ "sp-inherents",
  "sp-runtime",
  "sp-timestamp",
  "structopt",
@@ -4243,8 +4781,11 @@ dependencies = [
 
 [[package]]
 name = "peaq-node-runtime"
-version = "3.0.0-monthly-2021-10"
+version = "3.0.0-polkadot-v0.9.13"
 dependencies = [
+ "fp-evm",
+ "fp-rpc",
+ "fp-self-contained",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -4254,9 +4795,16 @@ dependencies = [
  "hex-literal",
  "pallet-aura",
  "pallet-balances",
+ "pallet-base-fee",
  "pallet-contracts",
  "pallet-contracts-primitives",
  "pallet-contracts-rpc-runtime-api",
+ "pallet-dynamic-fee",
+ "pallet-ethereum",
+ "pallet-evm",
+ "pallet-evm-precompile-modexp",
+ "pallet-evm-precompile-sha3fips",
+ "pallet-evm-precompile-simple",
  "pallet-grandpa",
  "pallet-multisig",
  "pallet-randomness-collective-flip",
@@ -4268,11 +4816,13 @@ dependencies = [
  "peaq-pallet-did",
  "peaq-pallet-transaction",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -4285,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-did"
 version = "0.0.1"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?tag=initial-2022-01#8d89788c04cdaf9ac8ec30f41bea2e2d0f3abd0b"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=feature/1201590612941083_evm_integration#00e387f16199e90b8aab7d8106fe7d012f330783"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4302,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-transaction"
 version = "0.0.1"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?tag=initial-2022-01#e6b6f05e7ce0cee4fdd4de14b1a48dc82b2b6437"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?branch=feature/1201590612941083_evm_integration#d57ca681f5c7165432dffadaf1970bf9293ec798"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4378,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -4388,27 +4938,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
 dependencies = [
- "pin-project-internal 0.4.28",
+ "pin-project-internal 0.4.29",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
- "pin-project-internal 1.0.8",
+ "pin-project-internal 1.0.10",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4417,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4434,9 +4984,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -4446,15 +4996,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "platforms"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
+checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polling"
@@ -4494,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
@@ -4506,6 +5056,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -4556,32 +5107,32 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "parking_lot 0.11.2",
- "regex",
+ "memchr",
+ "parking_lot",
  "thiserror",
 ]
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes 1.1.0",
  "prost-derive",
@@ -4589,27 +5140,29 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes 1.1.0",
  "heck",
  "itertools",
+ "lazy_static",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4620,9 +5173,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes 1.1.0",
  "prost",
@@ -4673,18 +5226,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radium"
@@ -4703,7 +5250,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -4753,14 +5300,14 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.4",
@@ -4791,6 +5338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -4826,12 +5382,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -4845,8 +5395,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
- "redox_syscall 0.2.10",
+ "getrandom 0.2.4",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4871,13 +5421,12 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "a6304468554ed921da3d32c355ea107b8d13d7b8996c3adfb7aab48d3bc321f4"
 dependencies = [
  "log",
  "rustc-hash",
- "serde",
  "smallvec",
 ]
 
@@ -4940,9 +5489,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
+checksum = "51dd4445360338dab5116712bee1388dc727991d51969558a8882ab552e6db30"
 
 [[package]]
 name = "ring"
@@ -4957,6 +5506,38 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4977,6 +5558,23 @@ checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rsix"
+version = "0.23.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64c5788d5aab8b75441499d99576a24eb09f76fb267b36fec7e3d970c66431"
+dependencies = [
+ "bitflags",
+ "cc",
+ "errno",
+ "io-lifetimes",
+ "itoa 0.4.8",
+ "libc",
+ "linux-raw-sys",
+ "once_cell",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -5016,12 +5614,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -5046,16 +5653,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.18",
- "pin-project 0.4.28",
+ "futures 0.3.19",
+ "pin-project 0.4.29",
  "static_assertions",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "safe-mix"
@@ -5068,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
  "cipher",
 ]
@@ -5086,8 +5693,8 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "4.1.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "sp-core",
@@ -5098,9 +5705,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5121,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5137,9 +5744,10 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
+ "memmap2 0.5.2",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network",
@@ -5153,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5164,11 +5772,11 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "chrono",
  "fdlimit",
- "futures 0.3.18",
+ "futures 0.3.19",
  "hex",
  "libp2p",
  "log",
@@ -5202,14 +5810,14 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "hash-db",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -5230,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5240,7 +5848,7 @@ dependencies = [
  "log",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-client-api",
  "sc-state-db",
  "sp-arithmetic",
@@ -5255,14 +5863,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-client-api",
  "sc-utils",
  "serde",
@@ -5279,11 +5887,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -5306,12 +5914,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-slots"
+name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.18",
+ "derive_more",
+ "fork-tree",
+ "futures 0.3.19",
+ "log",
+ "merlin",
+ "num-bigint 0.2.6",
+ "num-rational 0.2.4",
+ "num-traits",
+ "parity-scale-codec",
+ "parking_lot",
+ "rand 0.7.3",
+ "retain_mut",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-epochs",
+ "sc-consensus-slots",
+ "sc-keystore",
+ "sc-telemetry",
+ "schnorrkel",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-version",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-consensus-epochs"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "fork-tree",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "sc-consensus-manual-seal"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "assert_matches",
+ "async-trait",
+ "derive_more",
+ "futures 0.3.19",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-consensus-slots"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "async-trait",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5334,18 +6032,19 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "lazy_static",
- "libsecp256k1 0.6.0",
+ "libsecp256k1 0.7.0",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-executor-common",
  "sc-executor-wasmi",
  "sc-executor-wasmtime",
  "sp-api",
  "sp-core",
+ "sp-core-hashing-proc-macro",
  "sp-externalities",
  "sp-io",
  "sp-panic-handler",
@@ -5360,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "derive_more",
  "environmental",
@@ -5378,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5394,7 +6093,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -5412,18 +6111,18 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.8.4",
  "sc-block-builder",
  "sc-client-api",
@@ -5449,10 +6148,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "ansi_term 0.12.1",
- "futures 0.3.18",
+ "ansi_term",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-util-mem",
@@ -5466,12 +6165,12 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
  "hex",
- "parking_lot 0.11.2",
+ "parking_lot",
  "serde_json",
  "sp-application-crypto",
  "sp-core",
@@ -5479,27 +6178,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-light"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
-dependencies = [
- "hash-db",
- "parity-scale-codec",
- "parking_lot 0.11.2",
- "sc-client-api",
- "sc-executor",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
-]
-
-[[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5511,7 +6192,7 @@ dependencies = [
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
@@ -5519,10 +6200,10 @@ dependencies = [
  "linked-hash-map",
  "linked_hash_set",
  "log",
- "lru",
+ "lru 0.7.2",
  "parity-scale-codec",
- "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "parking_lot",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -5550,13 +6231,13 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "lru",
+ "lru 0.7.2",
  "sc-network",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -5566,19 +6247,19 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hex",
  "hyper",
  "hyper-rustls",
- "log",
  "num_cpus",
+ "once_cell",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.7.3",
  "sc-client-api",
  "sc-network",
@@ -5588,14 +6269,15 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "threadpool",
+ "tracing",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p",
  "log",
  "sc-utils",
@@ -5605,8 +6287,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5615,15 +6297,15 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -5646,16 +6328,16 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-chain-spec",
  "sc-transaction-pool-api",
  "serde",
@@ -5671,9 +6353,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
@@ -5688,12 +6370,12 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -5701,8 +6383,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "parking_lot",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -5712,7 +6394,6 @@ dependencies = [
  "sc-executor",
  "sc-informant",
  "sc-keystore",
- "sc-light",
  "sc-network",
  "sc-offchain",
  "sc-rpc",
@@ -5753,13 +6434,13 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sc-client-api",
  "sp-core",
 ]
@@ -5767,14 +6448,14 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "chrono",
- "futures 0.3.18",
+ "futures 0.3.19",
  "libp2p",
  "log",
- "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "parking_lot",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -5785,14 +6466,16 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "atty",
+ "chrono",
  "lazy_static",
+ "libc",
  "log",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "regex",
  "rustc-hash",
  "sc-client-api",
@@ -5814,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5825,15 +6508,15 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "intervalier",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.2",
+ "parking_lot",
  "retain_mut",
  "sc-client-api",
  "sc-transaction-pool-api",
@@ -5852,10 +6535,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "derive_more",
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
  "serde",
  "sp-blockchain",
@@ -5866,9 +6549,9 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "lazy_static",
  "prometheus",
@@ -5880,7 +6563,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
@@ -5941,26 +6624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5972,18 +6635,18 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -5994,9 +6657,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6027,6 +6690,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
  "serde",
 ]
 
@@ -6047,18 +6718,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6067,11 +6738,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -6115,15 +6786,28 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+dependencies = [
+ "block-buffer 0.7.3",
+ "byte-tools",
+ "digest 0.8.1",
+ "keccak",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -6155,9 +6839,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6174,9 +6858,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "simba"
@@ -6197,19 +6881,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-dependencies = [
- "erased-serde",
-]
-
-[[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snap"
@@ -6230,7 +6905,7 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "subtle 2.4.1",
  "x25519-dalek",
 ]
@@ -6248,9 +6923,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6258,24 +6933,24 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.4.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
+ "base64",
+ "bytes 1.1.0",
  "flate2",
- "futures 0.3.18",
+ "futures 0.3.19",
  "httparse",
  "log",
- "rand 0.7.3",
+ "rand 0.8.4",
  "sha-1 0.9.8",
 ]
 
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "log",
@@ -6292,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.1.0",
@@ -6304,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6317,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6332,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6344,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6356,13 +7031,13 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
- "lru",
+ "lru 0.7.2",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sp-api",
  "sp-consensus",
  "sp-database",
@@ -6374,10 +7049,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
- "futures 0.3.18",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -6393,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6409,39 +7084,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-babe"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "async-trait",
+ "merlin",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-arithmetic",
  "sp-runtime",
 ]
 
 [[package]]
+name = "sp-consensus-vrf"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "parity-scale-codec",
+ "schnorrkel",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "base58",
+ "bitflags",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.18",
+ "futures 0.3.19",
  "hash-db",
  "hash256-std-hasher",
  "hex",
  "impl-serde",
  "lazy_static",
- "libsecp256k1 0.6.0",
+ "libsecp256k1 0.7.0",
  "log",
  "merlin",
  "num-traits",
  "parity-scale-codec",
  "parity-util-mem",
- "parking_lot 0.11.2",
+ "parking_lot",
  "primitive-types",
  "rand 0.7.3",
  "regex",
@@ -6449,12 +7161,14 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
+ "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
+ "ss58-registry",
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
@@ -6465,18 +7179,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-core-hashing"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "blake2-rfc",
+ "byteorder",
+ "sha2 0.9.9",
+ "sp-std",
+ "tiny-keccak",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-core-hashing-proc-macro"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sp-core-hashing",
+ "syn",
+]
+
+[[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "kvdb",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
 name = "sp-debug-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6486,7 +7224,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6497,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6515,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6529,14 +7267,14 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "hash-db",
- "libsecp256k1 0.6.0",
+ "libsecp256k1 0.7.0",
  "log",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
@@ -6553,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6564,14 +7302,14 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.18",
+ "futures 0.3.19",
  "merlin",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "schnorrkel",
  "serde",
  "sp-core",
@@ -6580,8 +7318,8 @@ dependencies = [
 
 [[package]]
 name = "sp-maybe-compressed-blob"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "4.1.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "zstd",
 ]
@@ -6589,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6598,16 +7336,18 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "backtrace",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6617,7 +7357,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6639,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6656,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -6668,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6681,8 +7421,8 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "serde",
  "serde_json",
@@ -6691,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6705,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6716,13 +7456,13 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.7.3",
  "smallvec",
  "sp-core",
@@ -6739,12 +7479,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6757,7 +7497,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "log",
  "sp-core",
@@ -6770,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -6786,15 +7526,9 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "erased-serde",
- "log",
  "parity-scale-codec",
- "parking_lot 0.10.2",
- "serde",
- "serde_json",
- "slog",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -6804,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6813,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-trait",
  "log",
@@ -6829,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6844,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6860,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -6871,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6884,6 +7618,20 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "ss58-registry"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8319f44e20b42e5c11b88b1ad4130c35fe2974665a007b08b02322070177136a"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "unicode-xid",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -6918,9 +7666,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -6942,18 +7690,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6970,14 +7718,14 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "platforms",
 ]
@@ -6985,10 +7733,10 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.18",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7006,8 +7754,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7021,9 +7769,9 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?tag=monthly-2021-10#bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.13#3a5aa8c1a48b015b12e2419fa76b2e2530b3ac75"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "build-helper",
  "cargo_metadata",
  "sp-maybe-compressed-blob",
@@ -7047,9 +7795,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7076,20 +7824,20 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -7134,9 +7882,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -7173,7 +7921,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -7206,18 +7954,17 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg",
  "bytes 1.1.0",
  "libc",
  "memchr",
  "mio 0.7.14",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "signal-hook-registry",
  "winapi 0.3.9",
 ]
@@ -7240,7 +7987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -7254,7 +8001,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -7280,7 +8027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -7311,7 +8058,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "tracing",
 ]
 
@@ -7342,10 +8089,11 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",
@@ -7381,10 +8129,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.20.3"
+name = "triehash"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -7406,9 +8164,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-util",
@@ -7416,7 +8174,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.11.2",
+ "parking_lot",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -7430,10 +8188,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "twox-hash"
-version = "1.6.1"
+name = "tt-call"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.4",
@@ -7442,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -7454,9 +8218,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "1b1b413ebfe8c2c74a69ff124699dd156a7fa41cb1d09ba6df94aa2f2b0a4a3a"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -7512,7 +8276,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle 2.4.1",
 ]
 
@@ -7599,9 +8363,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -7650,9 +8414,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -7660,9 +8424,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -7675,9 +8439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -7687,9 +8451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7697,9 +8461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7710,9 +8474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-gc-api"
@@ -7731,9 +8495,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7767,15 +8531,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.79.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5894be15a559c85779254700e1d35f02f843b5a69152e5c82c626d9fd66c0e"
+checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
 
 [[package]]
 name = "wasmtime"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbb8a082a8ef50f7eeb8b82dda9709ef1e68963ea3c94e45581644dd4041835"
+checksum = "311d06b0c49346d1fbf48a17052e844036b95a7753c1afb34e8c0af3f6b5bb13"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7786,38 +8550,38 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "object",
  "paste",
  "psm",
+ "rayon",
  "region",
  "rustc-demangle",
  "serde",
- "smallvec",
  "target-lexicon",
  "wasmparser",
  "wasmtime-cache",
+ "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-jit",
- "wasmtime-profiling",
  "wasmtime-runtime",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73391579ca7f24573138ef768b73b2aed5f9d542385c64979b65d60d0912399"
+checksum = "36147930a4995137dc096e5b17a573b446799be2bbaea433e821ce6a80abe2c5"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64",
  "bincode",
  "directories-next",
- "errno",
  "file-per-thread-logger",
- "libc",
  "log",
+ "rsix",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -7825,63 +8589,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c6f5ae9205382345c7cd7454932a906186836999a2161c385e38a15f52e1fe"
-dependencies = [
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-wasm",
- "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-debug"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e08f55e12f15f50b1b533bc3626723e7224254a065de6576934c86258c9e8"
+checksum = "ab3083a47e1ede38aac06a1d9831640d673f9aeda0b82a64e4ce002f3432e2e7"
 dependencies = [
  "anyhow",
- "gimli 0.25.0",
- "more-asserts",
- "object 0.26.2",
- "target-lexicon",
- "thiserror",
- "wasmparser",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d93174040af37fb8625f891cd9827afdad314261f7ec4ee61ec497d6e9d3c"
-dependencies = [
- "cfg-if 1.0.0",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-wasm",
- "gimli 0.25.0",
- "indexmap",
- "log",
- "more-asserts",
- "serde",
- "thiserror",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmtime-jit"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bf1dfb213a35d8f21aefae40e597fe72778a907011ffdff7affb029a02af9a"
-dependencies = [
- "addr2line 0.16.0",
- "anyhow",
- "cfg-if 1.0.0",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
@@ -7890,60 +8602,64 @@ dependencies = [
  "gimli 0.25.0",
  "log",
  "more-asserts",
- "object 0.26.2",
- "rayon",
- "region",
+ "object",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2d194b655321053bc4111a1aa4ead552655c8a17d17264bc97766e70073510"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "cranelift-entity",
+ "gimli 0.25.0",
+ "indexmap",
+ "log",
+ "more-asserts",
+ "object",
  "serde",
  "target-lexicon",
  "thiserror",
  "wasmparser",
- "wasmtime-cranelift",
- "wasmtime-debug",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864ac8dfe4ce310ac59f16fdbd560c257389cb009ee5d030ac6e30523b023d11"
+dependencies = [
+ "addr2line 0.16.0",
+ "anyhow",
+ "bincode",
+ "cfg-if 1.0.0",
+ "gimli 0.25.0",
+ "log",
+ "more-asserts",
+ "object",
+ "region",
+ "rsix",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
  "wasmtime-environ",
- "wasmtime-obj",
- "wasmtime-profiling",
  "wasmtime-runtime",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "wasmtime-obj"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231491878e710c68015228c9f9fc5955fe5c96dbf1485c15f7bed55b622c83c"
-dependencies = [
- "anyhow",
- "more-asserts",
- "object 0.26.2",
- "target-lexicon",
- "wasmtime-debug",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-profiling"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21486cfb5255c2069666c1f116f9e949d4e35c9a494f11112fa407879e42198d"
-dependencies = [
- "anyhow",
- "cfg-if 1.0.0",
- "gimli 0.25.0",
- "lazy_static",
- "libc",
- "object 0.26.2",
- "scroll",
- "serde",
- "target-lexicon",
- "wasmtime-environ",
- "wasmtime-runtime",
-]
-
-[[package]]
 name = "wasmtime-runtime"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ddfdf32e0a20d81f48be9dacd31612bc61de5a174d1356fef806d300f507de"
+checksum = "ab97da813a26b98c9abfd3b0c2d99e42f6b78b749c0646344e2e262d212d8c8b"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7958,16 +8674,29 @@ dependencies = [
  "more-asserts",
  "rand 0.8.4",
  "region",
+ "rsix",
  "thiserror",
  "wasmtime-environ",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.55"
+name = "wasmtime-types"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "ff94409cc3557bfbbcce6b14520ccd6bd3727e965c0fe68d63ef2c185bf379c6"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8003,9 +8732,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
@@ -8103,28 +8832,28 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.18",
+ "futures 0.3.19",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand 0.8.4",
  "static_assertions",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8134,18 +8863,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.9.0+zstd.1.5.0"
+version = "0.9.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.1+zstd.1.5.0"
+version = "4.1.3+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -8153,9 +8882,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.1+zstd.1.5.0"
+version = "1.6.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 ]
 
 [patch.crates-io]
-ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }
+ethereum = { git = "https://github.com/peaqnetwork/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ members = [
     'node',
     'runtime',
 ]
+
+# [TODO] Need to solve it
+[patch.crates-io]
+ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ members = [
     'runtime',
 ]
 
-# [TODO] Need to solve it
 [patch.crates-io]
 ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -199,52 +199,52 @@ version = '0.3.3'
 # EVM
 [dependencies.fc-consensus]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fc-db]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fc-mapping-sync]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fc-rpc]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 features = [ "rpc_binary_search_estimate" ]
 
 [dependencies.fc-rpc-core]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fp-consensus]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fp-rpc]
 git = "https://github.com/purestake/frontier"
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-base-fee]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-dynamic-fee]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-ethereum]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 
 [dependencies.sc-consensus-manual-seal]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = 'peaq-node'
-version = '3.0.0-monthly-2021-10'
+version = '3.0.0-polkadot-v0.9.13'
 description = 'A node of the peaq network.'
 authors = ['peaq network <https://github.com/peaqnetwork>']
 homepage = 'https://peaq.network/'
-edition = '2018'
+edition = '2021'
 license = 'Unlicense'
 publish = false
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
@@ -17,175 +17,246 @@ name = 'peaq-node'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-build-script-utils]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '3.0.0'
 
 [dependencies.peaq-node-runtime]
 path = '../runtime'
-version = '3.0.0-monthly-2021-10'
+version = '3.0.0-polkadot-v0.9.13'
 
 [dependencies]
+structopt = "0.3.8"
+async-trait = "0.1"
+jsonrpc-pubsub = "18.0.0"
+futures = "0.3"
+log = "0.4.8"
+
 jsonrpc-core = '18.0.0'
-structopt = '0.3.8'
 
 [dependencies.frame-benchmarking]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-benchmarking-cli]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-basic-authorship]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-cli]
 features = ['wasmtime']
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-client-api]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-consensus]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-consensus-aura]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-executor]
 features = ['wasmtime']
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-finality-grandpa]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-keystore]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc-api]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-service]
 features = ['wasmtime']
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-telemetry]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool-api]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-api]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-blockchain]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-consensus]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-consensus-aura]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-finality-grandpa]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-timestamp]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.substrate-frame-rpc-system]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
+
+[dependencies.sp-inherents]
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 
 [dependencies.pallet-contracts]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-rpc]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-network]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.hex-literal]
 version = '0.3.3'
 
+
+# EVM
+[dependencies.fc-consensus]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.fc-db]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.fc-mapping-sync]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.fc-rpc]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+features = [ "rpc_binary_search_estimate" ]
+
+[dependencies.fc-rpc-core]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.fp-consensus]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.fp-rpc]
+git = "https://github.com/purestake/frontier"
+rev = '7927173a7'
+
+[dependencies.pallet-base-fee]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-dynamic-fee]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-ethereum]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-evm]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+
+[dependencies.sc-consensus-manual-seal]
+default-features = false
+git = 'https://github.com/purestake/substrate'
+branch = "moonbeam-polkadot-v0.9.13"
+
+
 [features]
-default = []
-runtime-benchmarks = ['peaq-node-runtime/runtime-benchmarks']
+default = ['aura']
+aura = ["peaq-node-runtime/aura"]
+manual-seal = ["peaq-node-runtime/manual-seal"]
+runtime-benchmarks = [
+	'peaq-node-runtime/runtime-benchmarks',
+]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,8 +17,8 @@ name = 'peaq-node'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-build-script-utils]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '3.0.0'
 
 [dependencies.peaq-node-runtime]
@@ -35,161 +35,161 @@ log = "0.4.8"
 jsonrpc-core = '18.0.0'
 
 [dependencies.frame-benchmarking]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-benchmarking-cli]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-basic-authorship]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-cli]
 features = ['wasmtime']
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-client-api]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-consensus]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-consensus-aura]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-executor]
 features = ['wasmtime']
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-finality-grandpa]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-keystore]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-rpc-api]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-service]
 features = ['wasmtime']
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sc-telemetry]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-transaction-pool-api]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-api]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-blockchain]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-consensus]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-consensus-aura]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-finality-grandpa]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-timestamp]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.substrate-frame-rpc-system]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-inherents]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 
 
 [dependencies.pallet-contracts]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-rpc]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sc-network]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.hex-literal]
@@ -198,59 +198,59 @@ version = '0.3.3'
 
 # EVM
 [dependencies.fc-consensus]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fc-db]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fc-mapping-sync]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fc-rpc]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 features = [ "rpc_binary_search_estimate" ]
 
 [dependencies.fc-rpc-core]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fp-consensus]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fp-rpc]
-git = "https://github.com/purestake/frontier"
-branch = 'moonbeam-polkadot-v0.9.13'
+git = "https://github.com/peaqnetwork/frontier"
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-base-fee]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-dynamic-fee]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-ethereum]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 
 [dependencies.sc-consensus-manual-seal]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = "moonbeam-polkadot-v0.9.13"
+git = 'https://github.com/peaqnetwork/substrate'
+branch = "peaq-polkadot-v0.9.13"
 
 
 [features]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,15 +1,15 @@
 use hex_literal::hex;
 use peaq_node_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
-	SystemConfig, WASM_BINARY,
+	AccountId, AuraConfig, BalancesConfig, EVMConfig, EthereumConfig, GenesisConfig, GrandpaConfig,
+	Signature, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_network::config::MultiaddrWithPeerId;
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{sr25519, Pair, Public, H160, U256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -167,21 +167,52 @@ fn testnet_genesis(
 		system: SystemConfig {
 			// Add Wasm runtime to storage.
 			code: wasm_binary.to_vec(),
-			changes_trie_config: Default::default(),
 		},
 		balances: BalancesConfig {
 			// Configure endowed accounts with initial balance of 1 << 60.
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, 1 << 60))
+				.collect(),
 		},
 		aura: AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
 		},
 		grandpa: GrandpaConfig {
-			authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
+			authorities: initial_authorities
+				.iter()
+				.map(|x| (x.1.clone(), 1))
+				.collect(),
 		},
 		sudo: SudoConfig {
 			// Assign network admin rights.
 			key: root_key,
 		},
+		evm: EVMConfig {
+			accounts: {
+				let mut map = BTreeMap::new();
+				map.insert(
+					// H160 address of Alice dev account
+					// Derived from SS58 (42 prefix) address
+					// SS58: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+					// hex: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+					// Using the full hex key, truncating to the first 20 bytes (the first 40 hex chars)
+					H160::from_str("d43593c715fdd31c61141abd04a99fd6822c8558")
+						.expect("internal H160 is valid; qed"),
+					pallet_evm::GenesisAccount {
+						balance: U256::from_str("0xffffffffffffffffffffffffffffffff")
+							.expect("internal U256 is valid; qed"),
+						code: Default::default(),
+						nonce: Default::default(),
+						storage: Default::default(),
+					},
+				);
+				map
+			},
+		},
+		ethereum: EthereumConfig {},
+		dynamic_fee: Default::default(),
+		base_fee: Default::default(),
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -175,7 +175,7 @@ fn testnet_genesis(
 			code: wasm_binary.to_vec(),
 		},
 		balances: BalancesConfig {
-			// Configure endowed accounts with initial balance of 1 << 60.
+			// Configure endowed accounts with initial balance of 1 << 78.
 			balances: endowed_accounts
 				.iter()
 				.cloned()

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,5 +1,53 @@
-use sc_cli::RunCmd;
+#[cfg(feature = "manual-seal")]
+use structopt::clap::arg_enum;
 use structopt::StructOpt;
+
+#[cfg(feature = "manual-seal")]
+arg_enum! {
+	/// Available Sealing methods.
+	#[derive(Debug, Copy, Clone, StructOpt)]
+	pub enum Sealing {
+		// Seal using rpc method.
+		Manual,
+		// Seal when transaction is executed.
+		Instant,
+	}
+}
+
+#[cfg(feature = "manual-seal")]
+impl Default for Sealing {
+	fn default() -> Sealing {
+		Sealing::Manual
+	}
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, StructOpt)]
+pub struct RunCmd {
+	#[allow(missing_docs)]
+	#[structopt(flatten)]
+	pub base: sc_cli::RunCmd,
+
+	#[cfg(feature = "manual-seal")]
+	/// Choose sealing method.
+	#[structopt(long = "sealing")]
+	pub sealing: Sealing,
+
+	#[structopt(long = "enable-dev-signer")]
+	pub enable_dev_signer: bool,
+
+	/// Maximum number of logs in a query.
+	#[structopt(long, default_value = "10000")]
+	pub max_past_logs: u32,
+
+	/// Maximum fee history cache size.
+	#[structopt(long, default_value = "2048")]
+	pub fee_history_limit: u64,
+
+	/// The dynamic-fee pallet target gas price set by block author
+	#[structopt(long, default_value = "1")]
+	pub target_gas_price: u64,
+}
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {
@@ -35,7 +83,7 @@ pub enum Subcommand {
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
 
-	/// The custom benchmark subcommand benchmarking runtime pallets.
+	/// The custom benchmark subcommmand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -83,7 +83,7 @@ pub enum Subcommand {
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
 
-	/// The custom benchmark subcommmand benchmarking runtime pallets.
+	/// The custom benchmark subcommand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,20 +1,3 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use crate::{
 	chain_spec,
 	cli::{Cli, Subcommand},
@@ -26,7 +9,7 @@ use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Frontier Node".into()
+		"PEAQ Node".into()
 	}
 
 	fn impl_version() -> String {
@@ -150,9 +133,9 @@ pub fn run() -> sc_cli::Result<()> {
 
 				runner.sync_run(|config| cmd.run::<Block, service::ExecutorDispatch>(config))
 			} else {
-				Err(
-					"Benchmarking wasn't enabled when building the node. You can enable it with `--features runtime-benchmarks`."
-						.into(),
+				Err("Benchmarking wasn't enabled when building the node. You can enable it with \
+				     `--features runtime-benchmarks`."
+					.into()
 				)
 			}
 		}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,0 @@
-pub mod chain_spec;
-pub mod rpc;
-pub mod service;

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -22,7 +22,9 @@ use sc_service::TransactionPool;
 use sc_transaction_pool::{ChainApi, Pool};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
-use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_blockchain::{
+	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata
+};
 use sp_runtime::traits::BlakeTwo256;
 
 //For ink! contracts
@@ -108,9 +110,11 @@ where
 	C::Api: BlockBuilder<Block>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
+	C::Api: fp_rpc::ConvertTransactionRuntimeApi<Block>,
 	P: TransactionPool<Block = Block> + 'static,
 	A: ChainApi<Block = Block> + 'static,
 
+	BE::Blockchain: BlockchainBackend<Block>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
 {
 	use fc_rpc::{
@@ -163,7 +167,7 @@ where
 		client.clone(),
 		pool.clone(),
 		graph,
-		peaq_node_runtime::TransactionConverter,
+		Some(peaq_node_runtime::TransactionConverter),
 		network.clone(),
 		signers,
 		overrides.clone(),

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -91,7 +91,7 @@ where
 	})
 }
 
-/// Instantiate all Full RPC extensions.
+/// Instantiate all full RPC extensions.
 pub fn create_full<C, P, BE, A>(
 	deps: FullDeps<C, P, A>,
 	subscription_task_executor: SubscriptionTaskExecutor,
@@ -136,8 +136,6 @@ where
 		fee_history_limit,
 		fee_history_cache,
 		enable_dev_signer,
-		// overrides,
-		// block_data_cache,
 	} = deps;
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,62 +1,225 @@
 //! A collection of node-specific RPC methods.
-//! Substrate provides the `sc-rpc` crate, which defines the core RPC layer
-//! used by Substrate nodes. This file extends those RPC definitions with
-//! capabilities that are specific to this project's runtime configuration.
 
-#![warn(missing_docs)]
+use std::{collections::BTreeMap, sync::Arc};
 
-use std::sync::Arc;
-
-use peaq_node_runtime::{opaque::Block, AccountId, Balance, Index, BlockNumber, Hash};
-pub use sc_rpc_api::DenyUnsafe;
-use sc_transaction_pool_api::TransactionPool;
+use fc_rpc::{
+	EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
+	SchemaV2Override, SchemaV3Override, StorageOverride,
+};
+use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
+use peaq_node_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Hash, Index};
+use jsonrpc_pubsub::manager::SubscriptionManager;
+use pallet_ethereum::EthereumStorageSchema;
+use sc_client_api::{
+	backend::{AuxStore, Backend, StateBackend, StorageProvider},
+	client::BlockchainEvents,
+};
+use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApi};
+use sc_network::NetworkService;
+use sc_rpc::SubscriptionTaskExecutor;
+use sc_rpc_api::DenyUnsafe;
+use sc_service::TransactionPool;
+use sc_transaction_pool::{ChainApi, Pool};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_runtime::traits::BlakeTwo256;
+
 //For ink! contracts
 use pallet_contracts_rpc::{Contracts, ContractsApi};
 
 /// Full client dependencies.
-pub struct FullDeps<C, P> {
+pub struct FullDeps<C, P, A: ChainApi> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
+	/// Graph pool instance.
+	pub graph: Arc<Pool<A>>,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
+	/// The Node authority flag
+	pub is_authority: bool,
+	/// Whether to enable dev signer
+	pub enable_dev_signer: bool,
+	/// Network service
+	pub network: Arc<NetworkService<Block, Hash>>,
+	/// EthFilterApi pool.
+	pub filter_pool: Option<FilterPool>,
+	/// Backend.
+	pub backend: Arc<fc_db::Backend<Block>>,
+	/// Maximum number of logs in a query.
+	pub max_past_logs: u32,
+	/// Maximum fee history cache size.
+	pub fee_history_limit: u64,
+	/// Fee history cache.
+	pub fee_history_cache: FeeHistoryCache,
+	/// Manual seal command sink
+	pub command_sink:
+		Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,
 }
 
-/// Instantiate all full RPC extensions.
-pub fn create_full<C, P>(deps: FullDeps<C, P>) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
+pub fn overrides_handle<C, BE>(client: Arc<C>) -> Arc<OverrideHandle<Block>>
 where
-	C: ProvideRuntimeApi<Block>,
-	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
+	C: Send + Sync + 'static,
+	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
+	BE: Backend<Block> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+{
+	let mut overrides_map = BTreeMap::new();
+	overrides_map.insert(
+		EthereumStorageSchema::V1,
+		Box::new(SchemaV1Override::new(client.clone()))
+			as Box<dyn StorageOverride<_> + Send + Sync>,
+	);
+	overrides_map.insert(
+		EthereumStorageSchema::V2,
+		Box::new(SchemaV2Override::new(client.clone()))
+			as Box<dyn StorageOverride<_> + Send + Sync>,
+	);
+	overrides_map.insert(
+		EthereumStorageSchema::V3,
+		Box::new(SchemaV3Override::new(client.clone()))
+			as Box<dyn StorageOverride<_> + Send + Sync>,
+	);
+
+	Arc::new(OverrideHandle {
+		schemas: overrides_map,
+		fallback: Box::new(RuntimeApiStorageOverride::new(client.clone())),
+	})
+}
+
+/// Instantiate all Full RPC extensions.
+pub fn create_full<C, P, BE, A>(
+	deps: FullDeps<C, P, A>,
+	subscription_task_executor: SubscriptionTaskExecutor,
+	overrides: Arc<OverrideHandle<Block>>,
+) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
+where
+	BE: Backend<Block> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
+	C: BlockchainEvents<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
-	P: TransactionPool + 'static,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
+	P: TransactionPool<Block = Block> + 'static,
+	A: ChainApi<Block = Block> + 'static,
+
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
 {
+	use fc_rpc::{
+		EthApi, EthApiServer, EthDevSigner, EthFilterApi, EthFilterApiServer, EthPubSubApi,
+		EthPubSubApiServer, EthSigner, HexEncodedIdProvider, NetApi, NetApiServer, Web3Api,
+		Web3ApiServer,
+	};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
-	let FullDeps { client, pool, deny_unsafe } = deps;
+	let FullDeps {
+		client,
+		pool,
+		graph,
+		deny_unsafe,
+		is_authority,
+		network,
+		filter_pool,
+		command_sink,
+		backend,
+		max_past_logs,
+		fee_history_limit,
+		fee_history_cache,
+		enable_dev_signer,
+		// overrides,
+		// block_data_cache,
+	} = deps;
 
-	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
-
-	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
+	io.extend_with(SystemApi::to_delegate(FullSystem::new(
+		client.clone(),
+		pool.clone(),
+		deny_unsafe,
+	)));
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
+		client.clone(),
+	)));
 
 	// Contracts RPC API extension
 	io.extend_with(
 		ContractsApi::to_delegate(Contracts::new(client.clone()))
 	);
 
-	// Extend this RPC with a custom API by using the following syntax.
-	// `YourRpcStruct` should have a reference to a client, which is needed
-	// to call into the runtime.
-	// `io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));`
+	let mut signers = Vec::new();
+	if enable_dev_signer {
+		signers.push(Box::new(EthDevSigner::new()) as Box<dyn EthSigner>);
+	}
+
+	let block_data_cache = Arc::new(EthBlockDataCache::new(50, 50));
+
+	io.extend_with(EthApiServer::to_delegate(EthApi::new(
+		client.clone(),
+		pool.clone(),
+		graph,
+		peaq_node_runtime::TransactionConverter,
+		network.clone(),
+		signers,
+		overrides.clone(),
+		backend.clone(),
+		is_authority,
+		max_past_logs,
+		block_data_cache.clone(),
+		fc_rpc::format::Legacy,
+		fee_history_limit,
+		fee_history_cache,
+	)));
+
+	if let Some(filter_pool) = filter_pool {
+		io.extend_with(EthFilterApiServer::to_delegate(EthFilterApi::new(
+			client.clone(),
+			backend,
+			filter_pool.clone(),
+			500 as usize, // max stored filters
+			overrides.clone(),
+			max_past_logs,
+			block_data_cache.clone(),
+		)));
+	}
+
+	io.extend_with(NetApiServer::to_delegate(NetApi::new(
+		client.clone(),
+		network.clone(),
+		// Whether to format the `peer_count` response as Hex (default) or not.
+		true,
+	)));
+
+	io.extend_with(Web3ApiServer::to_delegate(Web3Api::new(client.clone())));
+
+	io.extend_with(EthPubSubApiServer::to_delegate(EthPubSubApi::new(
+		pool.clone(),
+		client.clone(),
+		network.clone(),
+		SubscriptionManager::<HexEncodedIdProvider>::with_id_provider(
+			HexEncodedIdProvider::default(),
+			Arc::new(subscription_task_executor),
+		),
+		overrides,
+	)));
+
+	match command_sink {
+		Some(command_sink) => {
+			io.extend_with(
+				// We provide the rpc handler with the sending end of the channel to allow the rpc
+				// send EngineCommands to the background block authorship task.
+				ManualSealApi::to_delegate(ManualSeal::new(command_sink)),
+			);
+		}
+		_ => {}
+	}
 
 	io
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,27 +1,42 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use peaq_node_runtime::{self, opaque::Block, RuntimeApi};
-use sc_client_api::{ExecutorProvider, RemoteBackend};
+use crate::cli::Cli;
+#[cfg(feature = "manual-seal")]
+use crate::cli::Sealing;
+use async_trait::async_trait;
+use fc_consensus::FrontierBlockImport;
+use fc_mapping_sync::{MappingSyncWorker, SyncStrategy};
+use fc_rpc::EthTask;
+use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
+use peaq_node_runtime::{self, opaque::Block, RuntimeApi, SLOT_DURATION};
+use futures::StreamExt;
+use sc_cli::SubstrateCli;
+use sc_client_api::{BlockchainEvents, ExecutorProvider};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
+#[cfg(feature = "manual-seal")]
+use sc_consensus_manual_seal::{self as manual_seal};
 pub use sc_executor::NativeElseWasmExecutor;
 use sc_finality_grandpa::SharedVoterState;
 use sc_keystore::LocalKeystore;
-use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
+use sc_network::warp_request_handler::WarpSyncProvider;
+use sc_service::{error::Error as ServiceError, BasePath, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sp_consensus::SlotData;
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use std::{sync::Arc, time::Duration};
+use sp_core::U256;
+use sp_inherents::{InherentData, InherentIdentifier};
+use std::{
+	cell::RefCell,
+	collections::BTreeMap,
+	sync::{Arc, Mutex},
+	time::Duration,
+};
 
 // Our native executor instance.
 pub struct ExecutorDispatch;
 
 impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
-	/// Only enable the benchmarking host functions when we actually want to benchmark.
-	#[cfg(feature = "runtime-benchmarks")]
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-	/// Otherwise we only use the default Substrate host functions.
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type ExtendHostFunctions = ();
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
 		peaq_node_runtime::api::dispatch(method, data)
@@ -37,8 +52,78 @@ type FullClient =
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
+#[cfg(feature = "aura")]
+pub type ConsensusResult = (
+	FrontierBlockImport<
+		Block,
+		sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,
+		FullClient,
+	>,
+	sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
+);
+
+#[cfg(feature = "manual-seal")]
+pub type ConsensusResult = (
+	FrontierBlockImport<Block, Arc<FullClient>, FullClient>,
+	Sealing,
+);
+
+/// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
+/// Each call will increment timestamp by slot_duration making Aura think time has passed.
+pub struct MockTimestampInherentDataProvider;
+
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"timstap0";
+
+thread_local!(static TIMESTAMP: RefCell<u64> = RefCell::new(0));
+
+#[async_trait]
+impl sp_inherents::InherentDataProvider for MockTimestampInherentDataProvider {
+	fn provide_inherent_data(
+		&self,
+		inherent_data: &mut InherentData,
+	) -> Result<(), sp_inherents::Error> {
+		TIMESTAMP.with(|x| {
+			*x.borrow_mut() += SLOT_DURATION;
+			inherent_data.put_data(INHERENT_IDENTIFIER, &*x.borrow())
+		})
+	}
+
+	async fn try_handle_error(
+		&self,
+		_identifier: &InherentIdentifier,
+		_error: &[u8],
+	) -> Option<Result<(), sp_inherents::Error>> {
+		// The pallet never reports error.
+		None
+	}
+}
+
+pub fn frontier_database_dir(config: &Configuration) -> std::path::PathBuf {
+	let config_dir = config
+		.base_path
+		.as_ref()
+		.map(|base_path| base_path.config_dir(config.chain_spec.id()))
+		.unwrap_or_else(|| {
+			BasePath::from_project("", "", &crate::cli::Cli::executable_name())
+				.config_dir(config.chain_spec.id())
+		});
+	config_dir.join("frontier").join("db")
+}
+
+pub fn open_frontier_backend(config: &Configuration) -> Result<Arc<fc_db::Backend<Block>>, String> {
+	Ok(Arc::new(fc_db::Backend::<Block>::new(
+		&fc_db::DatabaseSettings {
+			source: fc_db::DatabaseSettingsSrc::RocksDb {
+				path: frontier_database_dir(&config),
+				cache_size: 0,
+			},
+		},
+	)?))
+}
+
 pub fn new_partial(
 	config: &Configuration,
+	cli: &Cli,
 ) -> Result<
 	sc_service::PartialComponents<
 		FullClient,
@@ -47,20 +132,19 @@ pub fn new_partial(
 		sc_consensus::DefaultImportQueue<Block, FullClient>,
 		sc_transaction_pool::FullPool<Block, FullClient>,
 		(
-			sc_finality_grandpa::GrandpaBlockImport<
-				FullBackend,
-				Block,
-				FullClient,
-				FullSelectChain,
-			>,
-			sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
+			ConsensusResult,
+			Option<FilterPool>,
+			Arc<fc_db::Backend<Block>>,
 			Option<Telemetry>,
+			FeeHistoryCache,
 		),
 	>,
 	ServiceError,
 > {
 	if config.keystore_remote.is_some() {
-		return Err(ServiceError::Other(format!("Remote Keystores are not supported.")))
+		return Err(ServiceError::Other(format!(
+			"Remote Keystores are not supported."
+		)));
 	}
 
 	let telemetry = config
@@ -89,7 +173,7 @@ pub fn new_partial(
 	let client = Arc::new(client);
 
 	let telemetry = telemetry.map(|(worker, telemetry)| {
-		task_manager.spawn_handle().spawn("telemetry", worker.run());
+		task_manager.spawn_handle().spawn("telemetry", None, worker.run());
 		telemetry
 	});
 
@@ -103,50 +187,105 @@ pub fn new_partial(
 		client.clone(),
 	);
 
-	let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
-		client.clone(),
-		&(client.clone() as Arc<_>),
-		select_chain.clone(),
-		telemetry.as_ref().map(|x| x.handle()),
-	)?;
+	let filter_pool: Option<FilterPool> = Some(Arc::new(Mutex::new(BTreeMap::new())));
+	let fee_history_cache: FeeHistoryCache = Arc::new(Mutex::new(BTreeMap::new()));
 
-	let slot_duration = sc_consensus_aura::slot_duration(&*client)?.slot_duration();
+	let frontier_backend = open_frontier_backend(config)?;
 
-	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, _>(ImportQueueParams {
-			block_import: grandpa_block_import.clone(),
-			justification_import: Some(Box::new(grandpa_block_import.clone())),
-			client: client.clone(),
-			create_inherent_data_providers: move |_, ()| async move {
-				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+	#[cfg(feature = "manual-seal")]
+	{
+		let sealing = cli.run.sealing;
 
-				let slot =
-					sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
-						*timestamp,
-						slot_duration,
-					);
+		let frontier_block_import =
+			FrontierBlockImport::new(client.clone(), client.clone(), frontier_backend.clone());
 
-				Ok((timestamp, slot))
-			},
-			spawner: &task_manager.spawn_essential_handle(),
-			can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(
-				client.executor().clone(),
+		let import_queue = sc_consensus_manual_seal::import_queue(
+			Box::new(frontier_block_import.clone()),
+			&task_manager.spawn_essential_handle(),
+			config.prometheus_registry(),
+		);
+
+		Ok(sc_service::PartialComponents {
+			client,
+			backend,
+			task_manager,
+			import_queue,
+			keystore_container,
+			select_chain,
+			transaction_pool,
+			other: (
+				(frontier_block_import, sealing),
+				filter_pool,
+				frontier_backend,
+				telemetry,
+				fee_history_cache,
 			),
-			registry: config.prometheus_registry(),
-			check_for_equivocation: Default::default(),
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-		})?;
+		})
+	}
 
-	Ok(sc_service::PartialComponents {
-		client,
-		backend,
-		task_manager,
-		import_queue,
-		keystore_container,
-		select_chain,
-		transaction_pool,
-		other: (grandpa_block_import, grandpa_link, telemetry),
-	})
+	#[cfg(feature = "aura")]
+	{
+		let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
+			client.clone(),
+			&(client.clone() as Arc<_>),
+			select_chain.clone(),
+			telemetry.as_ref().map(|x| x.handle()),
+		)?;
+
+		let frontier_block_import = FrontierBlockImport::new(
+			grandpa_block_import.clone(),
+			client.clone(),
+			frontier_backend.clone(),
+		);
+
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)?.slot_duration();
+		let target_gas_price = cli.run.target_gas_price;
+
+		let import_queue =
+			sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, _>(ImportQueueParams {
+				block_import: frontier_block_import.clone(),
+				justification_import: Some(Box::new(grandpa_block_import.clone())),
+				client: client.clone(),
+				create_inherent_data_providers: move |_, ()| async move {
+					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+					let slot =
+						sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
+							*timestamp,
+							slot_duration,
+						);
+
+					let dynamic_fee =
+						pallet_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
+
+					Ok((timestamp, slot, dynamic_fee))
+				},
+				spawner: &task_manager.spawn_essential_handle(),
+				can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(
+					client.executor().clone(),
+				),
+				registry: config.prometheus_registry(),
+				check_for_equivocation: Default::default(),
+				telemetry: telemetry.as_ref().map(|x| x.handle()),
+			})?;
+
+		Ok(sc_service::PartialComponents {
+			client,
+			backend,
+			task_manager,
+			import_queue,
+			keystore_container,
+			select_chain,
+			transaction_pool,
+			other: (
+				(frontier_block_import, grandpa_link),
+				filter_pool,
+				frontier_backend,
+				telemetry,
+				fee_history_cache,
+			),
+		})
+	}
 }
 
 fn remote_keystore(_url: &String) -> Result<Arc<LocalKeystore>, &'static str> {
@@ -157,7 +296,7 @@ fn remote_keystore(_url: &String) -> Result<Arc<LocalKeystore>, &'static str> {
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> {
+pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
 		backend,
@@ -166,25 +305,41 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 		mut keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (block_import, grandpa_link, mut telemetry),
-	} = new_partial(&config)?;
+		other: (consensus_result, filter_pool, frontier_backend, mut telemetry, fee_history_cache),
+	} = new_partial(&config, &cli)?;
 
 	if let Some(url) = &config.keystore_remote {
 		match remote_keystore(url) {
 			Ok(k) => keystore_container.set_remote_keystore(k),
-			Err(e) =>
+			Err(e) => {
 				return Err(ServiceError::Other(format!(
 					"Error hooking up remote keystore for {}: {}",
 					url, e
-				))),
+				)))
+			}
 		};
 	}
 
-	config.network.extra_sets.push(sc_finality_grandpa::grandpa_peers_set_config());
-	let warp_sync = Arc::new(sc_finality_grandpa::warp_proof::NetworkProvider::new(
-		backend.clone(),
-		grandpa_link.shared_authority_set().clone(),
-	));
+	let warp_sync: Option<Arc<dyn WarpSyncProvider<Block>>> = {
+		#[cfg(feature = "aura")]
+		{
+			config
+				.network
+				.extra_sets
+				.push(sc_finality_grandpa::grandpa_peers_set_config());
+			Some(Arc::new(
+				sc_finality_grandpa::warp_proof::NetworkProvider::new(
+					backend.clone(),
+					consensus_result.1.shared_authority_set().clone(),
+					Vec::default(),
+				),
+			))
+		}
+		#[cfg(feature = "manual-seal")]
+		{
+			None
+		}
+	};
 
 	let (network, system_rpc_tx, network_starter) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
@@ -193,10 +348,12 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			transaction_pool: transaction_pool.clone(),
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
-			on_demand: None,
 			block_announce_validator_builder: None,
-			warp_sync: Some(warp_sync),
+			warp_sync: warp_sync,
 		})?;
+
+	// Channel for the rpc handler to communicate with the authorship task.
+	let (command_sink, _commands_stream) = futures::channel::mpsc::channel(1000);
 
 	if config.offchain_worker.enabled {
 		sc_service::build_offchain_workers(
@@ -213,16 +370,45 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	let name = config.network.node_name.clone();
 	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
+	let is_authority = config.role.is_authority();
+	let enable_dev_signer = cli.run.enable_dev_signer;
+	let subscription_task_executor =
+		sc_rpc::SubscriptionTaskExecutor::new(task_manager.spawn_handle());
+	let overrides = crate::rpc::overrides_handle(client.clone());
+	let fee_history_limit = cli.run.fee_history_limit;
 
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();
+		let network = network.clone();
+		let filter_pool = filter_pool.clone();
+		let frontier_backend = frontier_backend.clone();
+		let overrides = overrides.clone();
+		let fee_history_cache = fee_history_cache.clone();
+		let max_past_logs = cli.run.max_past_logs;
 
 		Box::new(move |deny_unsafe, _| {
-			let deps =
-				crate::rpc::FullDeps { client: client.clone(), pool: pool.clone(), deny_unsafe };
+			let deps = crate::rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				graph: pool.pool().clone(),
+				deny_unsafe,
+				is_authority,
+				enable_dev_signer,
+				network: network.clone(),
+				filter_pool: filter_pool.clone(),
+				backend: frontier_backend.clone(),
+				max_past_logs,
+				fee_history_limit,
+				fee_history_cache: fee_history_cache.clone(),
+				command_sink: Some(command_sink.clone()),
+			};
 
-			Ok(crate::rpc::create_full(deps))
+			Ok(crate::rpc::create_full(
+				deps,
+				subscription_task_executor.clone(),
+				overrides.clone(),
+			))
 		})
 	};
 
@@ -233,244 +419,231 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 		task_manager: &mut task_manager,
 		transaction_pool: transaction_pool.clone(),
 		rpc_extensions_builder,
-		on_demand: None,
-		remote_blockchain: None,
-		backend,
+		backend: backend.clone(),
 		system_rpc_tx,
 		config,
 		telemetry: telemetry.as_mut(),
 	})?;
 
-	if role.is_authority() {
-		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
-			task_manager.spawn_handle(),
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-mapping-sync-worker",
+		Some("frontier"),
+		MappingSyncWorker::new(
+			client.import_notification_stream(),
+			Duration::new(6, 0),
 			client.clone(),
-			transaction_pool,
-			prometheus_registry.as_ref(),
-			telemetry.as_ref().map(|x| x.handle()),
-		);
-
-		let can_author_with =
-			sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
-
-		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
-		let raw_slot_duration = slot_duration.slot_duration();
-
-		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _, _>(
-			StartAuraParams {
-				slot_duration,
-				client: client.clone(),
-				select_chain,
-				block_import,
-				proposer_factory,
-				create_inherent_data_providers: move |_, ()| async move {
-					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-
-					let slot =
-						sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
-							*timestamp,
-							raw_slot_duration,
-						);
-
-					Ok((timestamp, slot))
-				},
-				force_authoring,
-				backoff_authoring_blocks,
-				keystore: keystore_container.sync_keystore(),
-				can_author_with,
-				sync_oracle: network.clone(),
-				justification_sync_link: network.clone(),
-				block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
-				max_block_proposal_slot_portion: None,
-				telemetry: telemetry.as_ref().map(|x| x.handle()),
-			},
-		)?;
-
-		// the AURA authoring task is considered essential, i.e. if it
-		// fails we take down the service with it.
-		task_manager.spawn_essential_handle().spawn_blocking("aura", aura);
-	}
-
-	// if the node isn't actively participating in consensus then it doesn't
-	// need a keystore, regardless of which protocol we use below.
-	let keystore =
-		if role.is_authority() { Some(keystore_container.sync_keystore()) } else { None };
-
-	let grandpa_config = sc_finality_grandpa::Config {
-		// FIXME #1578 make this available through chainspec
-		gossip_duration: Duration::from_millis(333),
-		justification_period: 512,
-		name: Some(name),
-		observer_enabled: false,
-		keystore,
-		local_role: role,
-		telemetry: telemetry.as_ref().map(|x| x.handle()),
-	};
-
-	if enable_grandpa {
-		// start the full GRANDPA voter
-		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
-		// this point the full voter should provide better guarantees of block
-		// and vote data availability than the observer. The observer has not
-		// been tested extensively yet and having most nodes in a network run it
-		// could lead to finality stalls.
-		let grandpa_config = sc_finality_grandpa::GrandpaParams {
-			config: grandpa_config,
-			link: grandpa_link,
-			network,
-			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry,
-			shared_voter_state: SharedVoterState::empty(),
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-		};
-
-		// the GRANDPA voter task is considered infallible, i.e.
-		// if it fails we take down the service with it.
-		task_manager.spawn_essential_handle().spawn_blocking(
-			"grandpa-voter",
-			sc_finality_grandpa::run_grandpa_voter(grandpa_config)?,
-		);
-	}
-
-	network_starter.start_network();
-	Ok(task_manager)
-}
-
-/// Builds a new service for a light client.
-pub fn new_light(mut config: Configuration) -> Result<TaskManager, ServiceError> {
-	let telemetry = config
-		.telemetry_endpoints
-		.clone()
-		.filter(|x| !x.is_empty())
-		.map(|endpoints| -> Result<_, sc_telemetry::Error> {
-			let worker = TelemetryWorker::new(16)?;
-			let telemetry = worker.handle().new_telemetry(endpoints);
-			Ok((worker, telemetry))
-		})
-		.transpose()?;
-
-	let executor = NativeElseWasmExecutor::<ExecutorDispatch>::new(
-		config.wasm_method,
-		config.default_heap_pages,
-		config.max_runtime_instances,
+			backend.clone(),
+			frontier_backend.clone(),
+			SyncStrategy::Normal,
+		)
+		.for_each(|()| futures::future::ready(())),
 	);
 
-	let (client, backend, keystore_container, mut task_manager, on_demand) =
-		sc_service::new_light_parts::<Block, RuntimeApi, _>(
-			&config,
-			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
-			executor,
-		)?;
-
-	let mut telemetry = telemetry.map(|(worker, telemetry)| {
-		task_manager.spawn_handle().spawn("telemetry", worker.run());
-		telemetry
-	});
-
-	config.network.extra_sets.push(sc_finality_grandpa::grandpa_peers_set_config());
-
-	let select_chain = sc_consensus::LongestChain::new(backend.clone());
-
-	let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
-		config.transaction_pool.clone(),
-		config.prometheus_registry(),
-		task_manager.spawn_essential_handle(),
-		client.clone(),
-		on_demand.clone(),
-	));
-
-	let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
-		client.clone(),
-		&(client.clone() as Arc<_>),
-		select_chain.clone(),
-		telemetry.as_ref().map(|x| x.handle()),
-	)?;
-
-	let slot_duration = sc_consensus_aura::slot_duration(&*client)?.slot_duration();
-
-	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, _>(ImportQueueParams {
-			block_import: grandpa_block_import.clone(),
-			justification_import: Some(Box::new(grandpa_block_import.clone())),
-			client: client.clone(),
-			create_inherent_data_providers: move |_, ()| async move {
-				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-
-				let slot =
-					sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
-						*timestamp,
-						slot_duration,
-					);
-
-				Ok((timestamp, slot))
-			},
-			spawner: &task_manager.spawn_essential_handle(),
-			can_author_with: sp_consensus::NeverCanAuthor,
-			registry: config.prometheus_registry(),
-			check_for_equivocation: Default::default(),
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-		})?;
-
-	let warp_sync = Arc::new(sc_finality_grandpa::warp_proof::NetworkProvider::new(
-		backend.clone(),
-		grandpa_link.shared_authority_set().clone(),
-	));
-
-	let (network, system_rpc_tx, network_starter) =
-		sc_service::build_network(sc_service::BuildNetworkParams {
-			config: &config,
-			client: client.clone(),
-			transaction_pool: transaction_pool.clone(),
-			spawn_handle: task_manager.spawn_handle(),
-			import_queue,
-			on_demand: Some(on_demand.clone()),
-			block_announce_validator_builder: None,
-			warp_sync: Some(warp_sync),
-		})?;
-
-	if config.offchain_worker.enabled {
-		sc_service::build_offchain_workers(
-			&config,
-			task_manager.spawn_handle(),
-			client.clone(),
-			network.clone(),
+	// Spawn Frontier EthFilterApi maintenance task.
+	if let Some(filter_pool) = filter_pool {
+		// Each filter is allowed to stay in the pool for 100 blocks.
+		const FILTER_RETAIN_THRESHOLD: u64 = 100;
+		task_manager.spawn_essential_handle().spawn(
+			"frontier-filter-pool",
+			Some("frontier"),
+			EthTask::filter_pool_task(Arc::clone(&client), filter_pool, FILTER_RETAIN_THRESHOLD),
 		);
 	}
 
-	let enable_grandpa = !config.disable_grandpa;
-	if enable_grandpa {
-		let name = config.network.node_name.clone();
+	// Spawn Frontier FeeHistory cache maintenance task.
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-fee-history",
+		Some("frontier"),
+		EthTask::fee_history_task(
+			Arc::clone(&client),
+			Arc::clone(&overrides),
+			fee_history_cache,
+			fee_history_limit,
+		),
+	);
 
-		let config = sc_finality_grandpa::Config {
-			gossip_duration: std::time::Duration::from_millis(333),
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-schema-cache-task",
+		Some("frontier"),
+		EthTask::ethereum_schema_cache_task(Arc::clone(&client), Arc::clone(&frontier_backend)),
+	);
+
+	#[cfg(feature = "manual-seal")]
+	{
+		let (block_import, sealing) = consensus_result;
+
+		if role.is_authority() {
+			let env = sc_basic_authorship::ProposerFactory::new(
+				task_manager.spawn_handle(),
+				client.clone(),
+				transaction_pool.clone(),
+				prometheus_registry.as_ref(),
+				telemetry.as_ref().map(|x| x.handle()),
+			);
+
+			let target_gas_price = cli.run.target_gas_price;
+
+			// Background authorship future
+			match sealing {
+				Sealing::Manual => {
+					let authorship_future =
+						manual_seal::run_manual_seal(manual_seal::ManualSealParams {
+							block_import,
+							env,
+							client,
+							pool: transaction_pool.clone(),
+							commands_stream,
+							select_chain,
+							consensus_data_provider: None,
+							create_inherent_data_providers: move |_, ()| async move {
+								let mock_timestamp = MockTimestampInherentDataProvider;
+
+								let dynamic_fee = pallet_dynamic_fee::InherentDataProvider(
+									U256::from(target_gas_price),
+								);
+
+								Ok((mock_timestamp, dynamic_fee))
+							},
+						});
+					// we spawn the future on a background thread managed by service.
+					task_manager
+						.spawn_essential_handle()
+						.spawn_blocking("manual-seal", Some("block-authoring"), authorship_future);
+				}
+				Sealing::Instant => {
+					let authorship_future =
+						manual_seal::run_instant_seal(manual_seal::InstantSealParams {
+							block_import,
+							env,
+							client: client.clone(),
+							pool: transaction_pool.clone(),
+							select_chain,
+							consensus_data_provider: None,
+							create_inherent_data_providers: move |_, ()| async move {
+								let mock_timestamp = MockTimestampInherentDataProvider;
+
+								let dynamic_fee = pallet_dynamic_fee::InherentDataProvider(
+									U256::from(target_gas_price),
+								);
+
+								Ok((mock_timestamp, dynamic_fee))
+							},
+						});
+					// we spawn the future on a background thread managed by service.
+					task_manager
+						.spawn_essential_handle()
+						.spawn_blocking("instant-seal", Some("block-authoring"), authorship_future);
+				}
+			};
+		}
+		log::info!("Manual Seal Ready");
+	}
+
+	#[cfg(feature = "aura")]
+	{
+		let (block_import, grandpa_link) = consensus_result;
+
+		if role.is_authority() {
+			let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+				task_manager.spawn_handle(),
+				client.clone(),
+				transaction_pool,
+				prometheus_registry.as_ref(),
+				telemetry.as_ref().map(|x| x.handle()),
+			);
+
+			let can_author_with =
+				sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone());
+
+			let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+			let raw_slot_duration = slot_duration.slot_duration();
+			let target_gas_price = cli.run.target_gas_price;
+
+			let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _, _>(
+				StartAuraParams {
+					slot_duration,
+					client: client.clone(),
+					select_chain,
+					block_import,
+					proposer_factory,
+					create_inherent_data_providers: move |_, ()| async move {
+						let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+						let slot =
+							sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
+								*timestamp,
+								raw_slot_duration,
+							);
+
+						let dynamic_fee =
+							pallet_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
+
+						Ok((timestamp, slot, dynamic_fee))
+					},
+					force_authoring,
+					backoff_authoring_blocks,
+					keystore: keystore_container.sync_keystore(),
+					can_author_with,
+					sync_oracle: network.clone(),
+					justification_sync_link: network.clone(),
+					block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
+					max_block_proposal_slot_portion: None,
+					telemetry: telemetry.as_ref().map(|x| x.handle()),
+				},
+			)?;
+
+			// the AURA authoring task is considered essential, i.e. if it
+			// fails we take down the service with it.
+			task_manager
+				.spawn_essential_handle()
+				.spawn_blocking("aura", Some("block-authoring"), aura);
+		}
+
+		// if the node isn't actively participating in consensus then it doesn't
+		// need a keystore, regardless of which protocol we use below.
+		let keystore = if role.is_authority() {
+			Some(keystore_container.sync_keystore())
+		} else {
+			None
+		};
+
+		let grandpa_config = sc_finality_grandpa::Config {
+			// FIXME #1578 make this available through chainspec
+			gossip_duration: Duration::from_millis(333),
 			justification_period: 512,
 			name: Some(name),
 			observer_enabled: false,
-			keystore: None,
-			local_role: config.role.clone(),
+			keystore,
+			local_role: role,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
 
-		task_manager.spawn_handle().spawn_blocking(
-			"grandpa-observer",
-			sc_finality_grandpa::run_grandpa_observer(config, grandpa_link, network.clone())?,
-		);
-	}
+		if enable_grandpa {
+			// start the full GRANDPA voter
+			// NOTE: non-authorities could run the GRANDPA observer protocol, but at
+			// this point the full voter should provide better guarantees of block
+			// and vote data availability than the observer. The observer has not
+			// been tested extensively yet and having most nodes in a network run it
+			// could lead to finality stalls.
+			let grandpa_config = sc_finality_grandpa::GrandpaParams {
+				config: grandpa_config,
+				link: grandpa_link,
+				network,
+				voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
+				prometheus_registry,
+				shared_voter_state: SharedVoterState::empty(),
+				telemetry: telemetry.as_ref().map(|x| x.handle()),
+			};
 
-	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
-		remote_blockchain: Some(backend.remote_blockchain()),
-		transaction_pool,
-		task_manager: &mut task_manager,
-		on_demand: Some(on_demand),
-		rpc_extensions_builder: Box::new(|_, _| Ok(())),
-		config,
-		client,
-		keystore: keystore_container.sync_keystore(),
-		backend,
-		network,
-		system_rpc_tx,
-		telemetry: telemetry.as_mut(),
-	})?;
+			// the GRANDPA voter task is considered infallible, i.e.
+			// if it fails we take down the service with it.
+			task_manager.spawn_essential_handle().spawn_blocking(
+				"grandpa-voter",
+				None,
+				sc_finality_grandpa::run_grandpa_voter(grandpa_config)?,
+			);
+		}
+	}
 
 	network_starter.start_network();
 	Ok(task_manager)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,8 +13,8 @@ repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-wasm-builder]
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '5.0.0-dev'
 
 [dependencies.codec]
@@ -31,40 +31,40 @@ version = '1.0.101'
 
 [dependencies.frame-benchmarking]
 default-features = false
-git = 'https://github.com/purestake/substrate'
+git = 'https://github.com/peaqnetwork/substrate'
 optional = true
-branch = 'moonbeam-polkadot-v0.9.13'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-executive]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-benchmarking]
 default-features = false
-git = 'https://github.com/purestake/substrate'
+git = 'https://github.com/peaqnetwork/substrate'
 optional = true
-branch = 'moonbeam-polkadot-v0.9.13'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.hex-literal]
@@ -73,50 +73,50 @@ version = '0.3.1'
 
 [dependencies.pallet-aura]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-balances]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-grandpa]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-sudo]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -127,86 +127,86 @@ version = '1.0'
 
 [dependencies.sp-api]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-consensus-aura]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-inherents]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-offchain]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-session]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-transaction-pool]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-version]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-primitives]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.peaq-pallet-did]
@@ -224,81 +224,81 @@ version = '0.0.1'
 
 [dependencies.pallet-multisig]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 
 # ### Ethereum
 [dependencies.sp-io]
 default-features = false
-git = 'https://github.com/purestake/substrate'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fp-evm]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fp-rpc]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.fp-self-contained]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-base-fee]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-dynamic-fee]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-ethereum]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-blake2]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-bn128]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-dispatch]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-modexp]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-sha3fips]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-simple]
 default-features = false
-git = 'https://github.com/purestake/frontier'
-branch = 'moonbeam-polkadot-v0.9.13'
+git = 'https://github.com/peaqnetwork/frontier'
+branch = 'peaq-polkadot-v0.9.13'
 
 
 [features]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -229,8 +229,7 @@ branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 
-# ### Frontier
-# [TODO] 
+# ### Ethereum
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/purestake/substrate'
@@ -286,7 +285,6 @@ rev = '7927173a7'
 # git = 'https://github.com/purestake/frontier'
 # rev = '7927173a7'
 
-# [TODO] Why in moonbeam/frontier it doesn't inside the features?
 [dependencies.pallet-evm-precompile-modexp]
 default-features = false
 git = 'https://github.com/purestake/frontier'

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -238,67 +238,67 @@ branch = 'moonbeam-polkadot-v0.9.13'
 [dependencies.fp-evm]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fp-rpc]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.fp-self-contained]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-base-fee]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-dynamic-fee]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-ethereum]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-blake2]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-bn128]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-dispatch]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-modexp]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-sha3fips]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 [dependencies.pallet-evm-precompile-simple]
 default-features = false
 git = 'https://github.com/purestake/frontier'
-rev = '7927173a7'
+branch = 'moonbeam-polkadot-v0.9.13'
 
 
 [features]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -270,20 +270,20 @@ default-features = false
 git = 'https://github.com/purestake/frontier'
 rev = '7927173a7'
 
-# [dependencies.pallet-evm-precompile-blake2]
-# default-features = false
-# git = 'https://github.com/purestake/frontier'
-# rev = '7927173a7'
+[dependencies.pallet-evm-precompile-blake2]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
 
-# [dependencies.pallet-evm-precompile-bn128]
-# default-features = false
-# git = 'https://github.com/purestake/frontier'
-# rev = '7927173a7'
+[dependencies.pallet-evm-precompile-bn128]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
 
-# [dependencies.pallet-evm-precompile-dispatch]
-# default-features = false
-# git = 'https://github.com/purestake/frontier'
-# rev = '7927173a7'
+[dependencies.pallet-evm-precompile-dispatch]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
 
 [dependencies.pallet-evm-precompile-modexp]
 default-features = false

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'peaq-node-runtime'
-version = '3.0.0-monthly-2021-10'
+version = '3.0.0-polkadot-v0.9.13'
 description = 'A node of the peaq network.'
 authors = ['peaq network <https://github.com/peaqnetwork>']
 homepage = 'https://peaq.network/'
@@ -13,8 +13,8 @@ repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies.substrate-wasm-builder]
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '5.0.0-dev'
 
 [dependencies.codec]
@@ -23,42 +23,48 @@ features = ['derive']
 package = 'parity-scale-codec'
 version = '2.0.0'
 
+[dependencies.serde]
+default-features = false
+features = ['derive']
+optional = true
+version = '1.0.101'
+
 [dependencies.frame-benchmarking]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
+git = 'https://github.com/purestake/substrate'
 optional = true
-tag = 'monthly-2021-10'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-executive]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-benchmarking]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
+git = 'https://github.com/purestake/substrate'
 optional = true
-tag = 'monthly-2021-10'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.frame-system-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.hex-literal]
@@ -67,50 +73,50 @@ version = '0.3.1'
 
 [dependencies.pallet-aura]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-balances]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-grandpa]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-randomness-collective-flip]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-sudo]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-timestamp]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-transaction-payment-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.scale-info]
@@ -118,111 +124,189 @@ default-features = false
 features = ['derive']
 version = '1.0'
 
+
 [dependencies.sp-api]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-block-builder]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-consensus-aura]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '0.10.0-dev'
 
 [dependencies.sp-core]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-inherents]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-offchain]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-session]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-transaction-pool]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.sp-version]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-primitives]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-rpc-runtime-api]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
 [dependencies.peaq-pallet-did]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-tag = 'initial-2022-01'
+branch = 'feature/1201590612941083_evm_integration'
 version = '0.0.1'
 
 [dependencies.peaq-pallet-transaction]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-transaction.git'
-tag = 'initial-2022-01'
+branch = 'feature/1201590612941083_evm_integration'
 version = '0.0.1'
 
 
 [dependencies.pallet-multisig]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
 version = '4.0.0-dev'
 
+
+# ### Frontier
+# [TODO] 
+[dependencies.sp-io]
+default-features = false
+git = 'https://github.com/purestake/substrate'
+branch = 'moonbeam-polkadot-v0.9.13'
+
+[dependencies.fp-evm]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.fp-rpc]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.fp-self-contained]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-base-fee]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-dynamic-fee]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-ethereum]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-evm]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+# [dependencies.pallet-evm-precompile-blake2]
+# default-features = false
+# git = 'https://github.com/purestake/frontier'
+# rev = '7927173a7'
+
+# [dependencies.pallet-evm-precompile-bn128]
+# default-features = false
+# git = 'https://github.com/purestake/frontier'
+# rev = '7927173a7'
+
+# [dependencies.pallet-evm-precompile-dispatch]
+# default-features = false
+# git = 'https://github.com/purestake/frontier'
+# rev = '7927173a7'
+
+# [TODO] Why in moonbeam/frontier it doesn't inside the features?
+[dependencies.pallet-evm-precompile-modexp]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-evm-precompile-sha3fips]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+[dependencies.pallet-evm-precompile-simple]
+default-features = false
+git = 'https://github.com/purestake/frontier'
+rev = '7927173a7'
+
+
 [features]
-default = ['std']
+default = ["std", "aura"]
+aura = []
+manual-seal = []
 runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
@@ -236,6 +320,8 @@ runtime-benchmarks = [
 ]
 std = [
     'codec/std',
+	"serde",
+
     'scale-info/std',
     'frame-executive/std',
     'frame-support/std',
@@ -266,4 +352,18 @@ std = [
     'pallet-contracts-rpc-runtime-api/std',
     'peaq-pallet-did/std',
     'peaq-pallet-transaction/std',
+
+	# ETH support
+	'sp-io/std',
+	'fp-evm/std',
+	'fp-self-contained/std',
+	'pallet-base-fee/std',
+	'pallet-dynamic-fee/std',
+	'pallet-ethereum/std',
+	'pallet-evm/std',
+	'pallet-evm-precompile-simple/std',
+	'pallet-evm-precompile-modexp/std',
+	'pallet-evm-precompile-sha3fips/std',
+	'sp-std/std',
+	'fp-rpc/std',
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -423,6 +423,8 @@ impl pallet_dynamic_fee::Config for Runtime {
 
 frame_support::parameter_types! {
 	pub IsActive: bool = true;
+	// [TODO]...
+	pub DefaultBaseFeePerGas: U256 = U256::from(1024);
 }
 
 pub struct BaseFeeThreshold;
@@ -442,6 +444,7 @@ impl pallet_base_fee::Config for Runtime {
 	type Event = Event;
 	type Threshold = BaseFeeThreshold;
 	type IsActive = IsActive;
+    type DefaultBaseFeePerGas = DefaultBaseFeePerGas;
 }
 
 impl pallet_randomness_collective_flip::Config for Runtime {}
@@ -783,6 +786,16 @@ impl_runtime_apis! {
 
 		fn elasticity() -> Option<Permill> {
 			Some(BaseFee::elasticity())
+		}
+	}
+
+	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
+		fn convert_transaction(
+				transaction: pallet_ethereum::Transaction
+				) -> <Block as BlockT>::Extrinsic {
+			UncheckedExtrinsic::new_unsigned(
+					pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
+					)
 		}
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,44 +6,57 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use codec::{Decode, Encode};
+use pallet_evm::FeeCalculator;
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_core::{
+	crypto::{KeyTypeId, Public},
+	OpaqueMetadata, H160, H256, U256,
+};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify},
-	transaction_validity::{TransactionSource, TransactionValidity},
+	traits::{
+		AccountIdLookup, BlakeTwo256, Block as BlockT, Dispatchable, IdentifyAccount, NumberFor,
+		PostDispatchInfoOf, Verify,
+	},
+	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResult, MultiSignature,
 };
-use sp_std::prelude::*;
+use sp_std::{marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
+use fp_rpc::TransactionStatus;
 pub use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{KeyOwnerProofSystem, Nothing, Randomness, StorageInfo},
+	traits::{FindAuthor, KeyOwnerProofSystem, Randomness},
+	traits::{Nothing, StorageInfo},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, IdentityFee, Weight,
+		IdentityFee, Weight,
 	},
-	StorageValue,
+	ConsensusEngineId, StorageValue,
 };
 pub use pallet_balances::Call as BalancesCall;
+
+use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
+use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, HashedAddressMapping, Runner};
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
-/// Import the template pallet.
-// pub use pallet_template;
-pub use peaq_pallet_did;
+mod precompiles;
+use precompiles::FrontierPrecompiles;
 
+pub use peaq_pallet_did;
 pub use peaq_pallet_transaction;
 
 //For ink!
@@ -59,6 +72,10 @@ pub type Signature = MultiSignature;
 /// to the public key of our transaction signing scheme.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
+/// The type for looking up accounts. We don't expect more than 4 billion of them, but you
+/// never know...
+pub type AccountIndex = u32;
+
 /// Balance of an account.
 pub type Balance = u128;
 
@@ -67,6 +84,9 @@ pub type Index = u32;
 
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
+
+/// Digest item type.
+pub type DigestItem = generic::DigestItem;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -139,7 +159,10 @@ const fn deposit(items: u32, bytes: u32) -> Balance {
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+	NativeVersion {
+		runtime_version: VERSION,
+		can_author_with: Default::default(),
+	}
 }
 
 /// We assume that ~10% of the block weight is consumed by `on_initialize` handlers.
@@ -213,8 +236,6 @@ impl frame_system::Config for Runtime {
 	type OnSetCode = ();
 }
 
-impl pallet_randomness_collective_flip::Config for Runtime {}
-
 parameter_types! {
 	pub const MaxAuthorities: u32 = 32;
 }
@@ -240,9 +261,9 @@ impl pallet_grandpa::Config for Runtime {
 	)>>::IdentificationTuple;
 
 	type HandleEquivocation = ();
+	type MaxAuthorities = MaxAuthorities;
 
 	type WeightInfo = ();
-	type MaxAuthorities = MaxAuthorities;
 }
 
 // For ink
@@ -294,9 +315,12 @@ parameter_types! {
 impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
-	type OnTimestampSet = Aura;
 	type MinimumPeriod = MinimumPeriod;
 	type WeightInfo = ();
+	#[cfg(feature = "aura")]
+	type OnTimestampSet = Aura;
+	#[cfg(feature = "manual-seal")]
+	type OnTimestampSet = ();
 }
 
 parameter_types! {
@@ -315,16 +339,18 @@ impl pallet_balances::Config for Runtime {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
+	type WeightInfo = ();
 }
 
 parameter_types! {
 	pub const TransactionByteFee: Balance = 1;
+	pub const OperationalFeeMultiplier: u8 = 5;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
 	type TransactionByteFee = TransactionByteFee;
+	type OperationalFeeMultiplier = OperationalFeeMultiplier;
 	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
@@ -341,6 +367,83 @@ impl peaq_pallet_did::Config for Runtime {
 	type Signature = Signature;
 	type Time = pallet_timestamp::Pallet<Runtime>;
 }
+
+// Pallet EVM
+pub struct FindAuthorTruncated<F>(PhantomData<F>);
+impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
+	fn find_author<'a, I>(digests: I) -> Option<H160>
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+	{
+		if let Some(author_index) = F::find_author(digests) {
+			let authority_id = Aura::authorities()[author_index as usize].clone();
+			return Some(H160::from_slice(&authority_id.to_raw_vec()[4..24]));
+		}
+		None
+	}
+}
+
+parameter_types! {
+	pub const ChainId: u64 = 9999;
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
+}
+
+impl pallet_evm::Config for Runtime {
+	type FeeCalculator = BaseFee;
+	type GasWeightMapping = ();
+	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
+	type CallOrigin = EnsureAddressTruncated;
+	type WithdrawOrigin = EnsureAddressTruncated;
+	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type Event = Event;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = FrontierPrecompiles<Self>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ChainId;
+	type BlockGasLimit = BlockGasLimit;
+	type OnChargeTransaction = ();
+	type FindAuthor = FindAuthorTruncated<Aura>;
+}
+
+impl pallet_ethereum::Config for Runtime {
+	type Event = Event;
+	type StateRoot = pallet_ethereum::IntermediateStateRoot;
+}
+
+frame_support::parameter_types! {
+	pub BoundDivision: U256 = U256::from(1024);
+}
+
+impl pallet_dynamic_fee::Config for Runtime {
+	type MinGasPriceBoundDivisor = BoundDivision;
+}
+
+frame_support::parameter_types! {
+	pub IsActive: bool = true;
+}
+
+pub struct BaseFeeThreshold;
+impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
+	fn lower() -> Permill {
+		Permill::zero()
+	}
+	fn ideal() -> Permill {
+		Permill::from_parts(500_000)
+	}
+	fn upper() -> Permill {
+		Permill::from_parts(1_000_000)
+	}
+}
+
+impl pallet_base_fee::Config for Runtime {
+	type Event = Event;
+	type Threshold = BaseFeeThreshold;
+	type IsActive = IsActive;
+}
+
+impl pallet_randomness_collective_flip::Config for Runtime {}
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
@@ -362,8 +465,38 @@ construct_runtime!(
 		PeaqDid: peaq_pallet_did::{Pallet, Call, Storage, Event<T>},
 		Transaction: peaq_pallet_transaction::{Pallet, Call, Storage, Event<T>},
 		MultiSig:  pallet_multisig::{Pallet, Call, Storage, Event<T>},
+
+		// // EVM
+		Ethereum: pallet_ethereum::{Pallet, Call, Storage, Event, Config, Origin},
+		EVM: pallet_evm::{Pallet, Config, Call, Storage, Event<T>},
+		DynamicFee: pallet_dynamic_fee::{Pallet, Call, Storage, Config, Inherent},
+		BaseFee: pallet_base_fee::{Pallet, Call, Storage, Config<T>, Event},
 	}
 );
+
+pub struct TransactionConverter;
+
+impl fp_rpc::ConvertTransaction<UncheckedExtrinsic> for TransactionConverter {
+	fn convert_transaction(&self, transaction: pallet_ethereum::Transaction) -> UncheckedExtrinsic {
+		UncheckedExtrinsic::new_unsigned(
+			pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
+		)
+	}
+}
+
+impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConverter {
+	fn convert_transaction(
+		&self,
+		transaction: pallet_ethereum::Transaction,
+	) -> opaque::UncheckedExtrinsic {
+		let extrinsic = UncheckedExtrinsic::new_unsigned(
+			pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
+		);
+		let encoded = extrinsic.encode();
+		opaque::UncheckedExtrinsic::decode(&mut &encoded[..])
+			.expect("Encoded extrinsic is always valid")
+	}
+}
 
 /// The address format for describing accounts.
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
@@ -371,6 +504,11 @@ pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+/// A Block signed with a Justification
+pub type SignedBlock = generic::SignedBlock<Block>;
+/// BlockId type as expected by this runtime.
+pub type BlockId = generic::BlockId<Block>;
+
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
 	frame_system::CheckSpecVersion<Runtime>,
@@ -382,7 +520,10 @@ pub type SignedExtra = (
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+pub type UncheckedExtrinsic =
+	fp_self_contained::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+/// Extrinsic type that has already been checked.
+pub type CheckedExtrinsic = fp_self_contained::CheckedExtrinsic<AccountId, Call, SignedExtra, H160>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -392,6 +533,53 @@ pub type Executive = frame_executive::Executive<
 	AllPallets,
 >;
 
+impl fp_self_contained::SelfContainedCall for Call {
+	type SignedInfo = H160;
+
+	fn is_self_contained(&self) -> bool {
+		match self {
+			Call::Ethereum(call) => call.is_self_contained(),
+			_ => false,
+		}
+	}
+
+	fn check_self_contained(&self) -> Option<Result<Self::SignedInfo, TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.check_self_contained(),
+			_ => None,
+		}
+	}
+
+	fn validate_self_contained(&self, info: &Self::SignedInfo) -> Option<TransactionValidity> {
+		match self {
+			Call::Ethereum(call) => call.validate_self_contained(info),
+			_ => None,
+		}
+	}
+
+	fn pre_dispatch_self_contained(
+		&self,
+		info: &Self::SignedInfo,
+	) -> Option<Result<(), TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			_ => None,
+		}
+	}
+
+	fn apply_self_contained(
+		self,
+		info: Self::SignedInfo,
+	) -> Option<sp_runtime::DispatchResultWithInfo<PostDispatchInfoOf<Self>>> {
+		match self {
+			call @ Call::Ethereum(pallet_ethereum::Call::transact { .. }) => Some(call.dispatch(
+				Origin::from(pallet_ethereum::RawOrigin::EthereumTransaction(info)),
+			)),
+			_ => None,
+		}
+	}
+}
+
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
@@ -399,7 +587,7 @@ impl_runtime_apis! {
 		}
 
 		fn execute_block(block: Block) {
-			Executive::execute_block(block);
+			Executive::execute_block(block)
 		}
 
 		fn initialize_block(header: &<Block as BlockT>::Header) {
@@ -456,7 +644,163 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			Aura::authorities().into_inner()
+			Aura::authorities().to_vec()
+		}
+	}
+
+	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
+		fn account_nonce(account: AccountId) -> Index {
+			System::account_nonce(account)
+		}
+	}
+
+	impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {
+		fn chain_id() -> u64 {
+			<Runtime as pallet_evm::Config>::ChainId::get()
+		}
+
+		fn account_basic(address: H160) -> EVMAccount {
+			EVM::account_basic(&address)
+		}
+
+		fn gas_price() -> U256 {
+			<Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price()
+		}
+
+		fn account_code_at(address: H160) -> Vec<u8> {
+			EVM::account_codes(address)
+		}
+
+		fn author() -> H160 {
+			<pallet_evm::Pallet<Runtime>>::find_author()
+		}
+
+		fn storage_at(address: H160, index: U256) -> H256 {
+			let mut tmp = [0u8; 32];
+			index.to_big_endian(&mut tmp);
+			EVM::account_storages(address, H256::from_slice(&tmp[..]))
+		}
+
+		fn call(
+			from: H160,
+			to: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			max_fee_per_gas: Option<U256>,
+			max_priority_fee_per_gas: Option<U256>,
+			nonce: Option<U256>,
+			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
+		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
+			let config = if estimate {
+				let mut config = <Runtime as pallet_evm::Config>::config().clone();
+				config.estimate = true;
+				Some(config)
+			} else {
+				None
+			};
+
+			<Runtime as pallet_evm::Config>::Runner::call(
+				from,
+				to,
+				data,
+				value,
+				gas_limit.low_u64(),
+				max_fee_per_gas,
+				max_priority_fee_per_gas,
+				nonce,
+				access_list.unwrap_or_default(),
+				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
+			).map_err(|err| err.into())
+		}
+
+		fn create(
+			from: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			max_fee_per_gas: Option<U256>,
+			max_priority_fee_per_gas: Option<U256>,
+			nonce: Option<U256>,
+			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
+		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
+			let config = if estimate {
+				let mut config = <Runtime as pallet_evm::Config>::config().clone();
+				config.estimate = true;
+				Some(config)
+			} else {
+				None
+			};
+
+			<Runtime as pallet_evm::Config>::Runner::create(
+				from,
+				data,
+				value,
+				gas_limit.low_u64(),
+				max_fee_per_gas,
+				max_priority_fee_per_gas,
+				nonce,
+				access_list.unwrap_or_default(),
+				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
+			).map_err(|err| err.into())
+		}
+
+		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {
+			Ethereum::current_transaction_statuses()
+		}
+
+		fn current_block() -> Option<pallet_ethereum::Block> {
+			Ethereum::current_block()
+		}
+
+		fn current_receipts() -> Option<Vec<pallet_ethereum::Receipt>> {
+			Ethereum::current_receipts()
+		}
+
+		fn current_all() -> (
+			Option<pallet_ethereum::Block>,
+			Option<Vec<pallet_ethereum::Receipt>>,
+			Option<Vec<TransactionStatus>>
+		) {
+			(
+				Ethereum::current_block(),
+				Ethereum::current_receipts(),
+				Ethereum::current_transaction_statuses()
+			)
+		}
+
+		fn extrinsic_filter(
+			xts: Vec<<Block as BlockT>::Extrinsic>,
+		) -> Vec<EthereumTransaction> {
+			xts.into_iter().filter_map(|xt| match xt.0.function {
+				Call::Ethereum(transact { transaction }) => Some(transaction),
+				_ => None
+			}).collect::<Vec<EthereumTransaction>>()
+		}
+
+		fn elasticity() -> Option<Permill> {
+			Some(BaseFee::elasticity())
+		}
+	}
+
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
+		Block,
+		Balance,
+	> for Runtime {
+		fn query_info(
+			uxt: <Block as BlockT>::Extrinsic,
+			len: u32
+		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_info(uxt, len)
+		}
+
+		fn query_fee_details(
+			uxt: <Block as BlockT>::Extrinsic,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_fee_details(uxt, len)
 		}
 	}
 
@@ -499,27 +843,6 @@ impl_runtime_apis! {
 			// defined our key owner proof type as a bottom type (i.e. a type
 			// with no values).
 			None
-		}
-	}
-
-	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
-		fn account_nonce(account: AccountId) -> Index {
-			System::account_nonce(account)
-		}
-	}
-
-	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
-		fn query_info(
-			uxt: <Block as BlockT>::Extrinsic,
-			len: u32,
-		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
-		}
-		fn query_fee_details(
-			uxt: <Block as BlockT>::Extrinsic,
-			len: u32,
-		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
 		}
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -54,7 +54,8 @@ pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
 mod precompiles;
-use precompiles::FrontierPrecompiles;
+pub use precompiles::PeaqPrecompiles;
+pub type Precompiles = PeaqPrecompiles<Runtime>;
 
 pub use peaq_pallet_did;
 pub use peaq_pallet_transaction;
@@ -386,7 +387,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 parameter_types! {
 	pub const ChainId: u64 = 9999;
 	pub BlockGasLimit: U256 = U256::from(u32::max_value());
-	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
+	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 
 impl pallet_evm::Config for Runtime {
@@ -399,7 +400,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type PrecompilesType = FrontierPrecompiles<Self>;
+	type PrecompilesType = PeaqPrecompiles<Self>;
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = ChainId;
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -1,0 +1,62 @@
+use pallet_evm::{Context, Precompile, PrecompileResult, PrecompileSet};
+use sp_core::H160;
+use sp_std::marker::PhantomData;
+
+use pallet_evm_precompile_modexp::Modexp;
+use pallet_evm_precompile_sha3fips::Sha3FIPS256;
+use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
+
+pub struct FrontierPrecompiles<R>(PhantomData<R>);
+
+impl<R> FrontierPrecompiles<R>
+where
+	R: pallet_evm::Config,
+{
+	pub fn new() -> Self {
+		Self(Default::default())
+	}
+	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
+		sp_std::vec![1, 2, 3, 4, 5, 1024, 1025]
+			.into_iter()
+			.map(|x| hash(x))
+			.collect()
+	}
+}
+impl<R> PrecompileSet for FrontierPrecompiles<R>
+where
+	R: pallet_evm::Config,
+{
+	fn execute(
+		&self,
+		address: H160,
+		input: &[u8],
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> Option<PrecompileResult> {
+		match address {
+			// Ethereum precompiles :
+			a if a == hash(1) => Some(ECRecover::execute(input, target_gas, context, is_static)),
+			a if a == hash(2) => Some(Sha256::execute(input, target_gas, context, is_static)),
+			a if a == hash(3) => Some(Ripemd160::execute(input, target_gas, context, is_static)),
+			a if a == hash(4) => Some(Identity::execute(input, target_gas, context, is_static)),
+			a if a == hash(5) => Some(Modexp::execute(input, target_gas, context, is_static)),
+			// Non-Frontier specific nor Ethereum precompiles :
+			a if a == hash(1024) => {
+				Some(Sha3FIPS256::execute(input, target_gas, context, is_static))
+			}
+			a if a == hash(1025) => Some(ECRecoverPublicKey::execute(
+				input, target_gas, context, is_static,
+			)),
+			_ => None,
+		}
+	}
+
+	fn is_precompile(&self, address: H160) -> bool {
+		Self::used_addresses().contains(&address)
+	}
+}
+
+fn hash(a: u64) -> H160 {
+	H160::from_low_u64_be(a)
+}

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -5,25 +5,32 @@ use sp_std::marker::PhantomData;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
+use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
+use pallet_evm_precompile_blake2::Blake2F;
+use pallet_evm_precompile_dispatch::Dispatch;
 
-pub struct FrontierPrecompiles<R>(PhantomData<R>);
+pub struct PeaqPrecompiles<R>(PhantomData<R>);
 
-impl<R> FrontierPrecompiles<R>
+impl<R> PeaqPrecompiles<R>
 where
 	R: pallet_evm::Config,
 {
 	pub fn new() -> Self {
 		Self(Default::default())
 	}
-	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
-		sp_std::vec![1, 2, 3, 4, 5, 1024, 1025]
+
+	/// Return all addresses that contain precompiles. This can be used to populate dummy code
+	/// under the precompile.
+	pub fn used_addresses() -> impl Iterator<Item = H160> {
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 1024, 1025, 1026]
 			.into_iter()
 			.map(|x| hash(x))
-			.collect()
 	}
+
 }
-impl<R> PrecompileSet for FrontierPrecompiles<R>
+impl<R> PrecompileSet for PeaqPrecompiles<R>
 where
+	Dispatch<R>: Precompile,
 	R: pallet_evm::Config,
 {
 	fn execute(
@@ -41,11 +48,18 @@ where
 			a if a == hash(3) => Some(Ripemd160::execute(input, target_gas, context, is_static)),
 			a if a == hash(4) => Some(Identity::execute(input, target_gas, context, is_static)),
 			a if a == hash(5) => Some(Modexp::execute(input, target_gas, context, is_static)),
-			// Non-Frontier specific nor Ethereum precompiles :
+			a if a == hash(6) => Some(Bn128Add::execute(input, target_gas, context, is_static)),
+			a if a == hash(7) => Some(Bn128Mul::execute(input, target_gas, context, is_static)),
+			a if a == hash(8) => Some(Bn128Pairing::execute(input, target_gas, context, is_static)),
+			a if a == hash(9) => Some(Blake2F::execute(input, target_gas, context, is_static)),
+			// nor Ethereum precompiles :
 			a if a == hash(1024) => {
 				Some(Sha3FIPS256::execute(input, target_gas, context, is_static))
 			}
-			a if a == hash(1025) => Some(ECRecoverPublicKey::execute(
+            a if a == hash(1025) => Some(Dispatch::<R>::execute(
+                input, target_gas, context, is_static,
+            )),
+			a if a == hash(1026) => Some(ECRecoverPublicKey::execute(
 				input, target_gas, context, is_static,
 			)),
 			_ => None,
@@ -53,7 +67,7 @@ where
 	}
 
 	fn is_precompile(&self, address: H160) -> bool {
-		Self::used_addresses().contains(&address)
+		Self::used_addresses().find(|x| x == &address).is_some()
 	}
 }
 


### PR DESCRIPTION
**This PR includes**
1. Upgrade substrate-node-template (3.0.0-monthly-2021-10 865c0c01) to parity/frontier (frontier-para b4100366)
2. Add EVM/Ethereum pallet and Ethereum RPC calls
3. Integrate Ethereum's precompilation smart contracts.

**Note:**
1. I fork moonbeam's projects (`purestake/substrate`, `purestake/frontier` and `purestake/ethereum`) to keep the dependencies are clean. So we need to use our `peaqnetwork/substrate` and `peaqnetwork/frontier` projects to make pallets/nodes use the same toolchain.

![image](https://user-images.githubusercontent.com/1863472/153191766-9f880a17-5404-4ae0-869a-6c35b8f502a8.png)

2. To change the dependencies in pallet-peaq-transaction and pallet-peaq-did are necessary because they also need to be built by the same dependencies.