### PR TITLE
Feature/1201928607134510 support eth explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4768,6 +4768,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "peaq-client-evm-tracing"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types",
+ "evm-tracing-events",
+ "hex",
+ "parity-scale-codec",
+ "peaq-rpc-primitives-debug",
+ "serde",
+ "serde_json",
+ "sp-std",
+]
+
+[[package]]
 name = "peaq-evm-tracer"
 version = "0.1.0"
 dependencies = [
@@ -4813,6 +4827,11 @@ dependencies = [
  "pallet-evm",
  "pallet-transaction-payment-rpc",
  "peaq-node-runtime",
+ "peaq-rpc-debug",
+ "peaq-rpc-primitives-debug",
+ "peaq-rpc-primitives-txpool",
+ "peaq-rpc-trace",
+ "peaq-rpc-txpool",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -4842,6 +4861,7 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "tokio",
 ]
 
 [[package]]
@@ -4952,6 +4972,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "peaq-rpc-core-debug"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types",
+ "futures 0.3.21",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "peaq-client-evm-tracing",
+ "peaq-rpc-core-types",
+ "serde",
+ "serde_json",
+ "sp-core",
+]
+
+[[package]]
+name = "peaq-rpc-core-trace"
+version = "0.6.0"
+dependencies = [
+ "ethereum-types",
+ "futures 0.3.21",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "peaq-client-evm-tracing",
+ "peaq-rpc-core-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "peaq-rpc-core-txpool"
+version = "0.6.0"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fc-rpc-core",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "peaq-rpc-core-types"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "peaq-rpc-debug"
+version = "0.1.0"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fc-consensus",
+ "fc-db",
+ "fc-rpc",
+ "fp-rpc",
+ "futures 0.3.21",
+ "hex-literal",
+ "jsonrpc-core",
+ "peaq-client-evm-tracing",
+ "peaq-rpc-core-debug",
+ "peaq-rpc-core-types",
+ "peaq-rpc-primitives-debug",
+ "sc-client-api",
+ "sc-utils",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "peaq-rpc-primitives-debug"
 version = "0.1.0"
 dependencies = [
@@ -4976,6 +5078,60 @@ dependencies = [
  "ethereum",
  "parity-scale-codec",
  "sp-api",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "peaq-rpc-trace"
+version = "0.6.0"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fc-consensus",
+ "fc-rpc",
+ "fc-rpc-core",
+ "fp-rpc",
+ "futures 0.3.21",
+ "jsonrpc-core",
+ "peaq-client-evm-tracing",
+ "peaq-rpc-core-trace",
+ "peaq-rpc-core-types",
+ "peaq-rpc-primitives-debug",
+ "sc-client-api",
+ "sc-network",
+ "sc-utils",
+ "serde",
+ "sha3 0.9.1",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-transaction-pool",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "peaq-rpc-txpool"
+version = "0.6.0"
+dependencies = [
+ "ethereum-types",
+ "fc-rpc",
+ "frame-system",
+ "jsonrpc-core",
+ "peaq-rpc-core-txpool",
+ "peaq-rpc-primitives-txpool",
+ "rlp",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sha3 0.9.1",
+ "sp-api",
+ "sp-blockchain",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -8090,7 +8246,19 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "signal-hook-registry",
  "socket2 0.4.4",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "pallet-evm",
  "pallet-transaction-payment-rpc",
  "peaq-node-runtime",
+ "peaq-primitives-ext",
  "peaq-rpc-debug",
  "peaq-rpc-primitives-debug",
  "peaq-rpc-primitives-txpool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm-tracing-events"
+version = "0.1.0"
+dependencies = [
+ "environmental",
+ "ethereum",
+ "ethereum-types",
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
+ "parity-scale-codec",
+ "sp-runtime-interface",
+]
+
+[[package]]
 name = "exit-future"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2314,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -4751,6 +4768,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "peaq-evm-tracer"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types",
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
+ "evm-tracing-events",
+ "fp-evm",
+ "pallet-evm",
+ "parity-scale-codec",
+ "peaq-primitives-ext",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "peaq-node"
 version = "3.0.0-polkadot-v0.9.16"
 dependencies = [
@@ -4812,6 +4848,7 @@ dependencies = [
 name = "peaq-node-runtime"
 version = "3.0.0-polkadot-v0.9.16"
 dependencies = [
+ "evm-tracing-events",
  "fp-evm",
  "fp-rpc",
  "fp-self-contained",
@@ -4845,10 +4882,15 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "peaq-evm-tracer",
  "peaq-pallet-did",
  "peaq-pallet-transaction",
+ "peaq-rpc-primitives-debug",
+ "peaq-rpc-primitives-txpool",
+ "rlp",
  "scale-info",
  "serde",
+ "sha3 0.8.2",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -4895,6 +4937,48 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+]
+
+[[package]]
+name = "peaq-primitives-ext"
+version = "0.1.0"
+dependencies = [
+ "ethereum-types",
+ "evm-tracing-events",
+ "parity-scale-codec",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+]
+
+[[package]]
+name = "peaq-rpc-primitives-debug"
+version = "0.1.0"
+dependencies = [
+ "environmental",
+ "ethereum",
+ "ethereum-types",
+ "hex",
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "peaq-rpc-primitives-txpool"
+version = "0.6.0"
+dependencies = [
+ "ethereum",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/client/evm-tracing/Cargo.toml
+++ b/client/evm-tracing/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "peaq-client-evm-tracing"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+ethereum-types = { version = "0.12.1" }
+hex = { version = "0.4", features = [ "serde" ] }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = { version = "1.0" }
+
+evm-tracing-events = { path = "../../primitives/rpc/evm-tracing-events" }
+peaq-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }

--- a/client/evm-tracing/Cargo.toml
+++ b/client/evm-tracing/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-client-evm-tracing"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/client/evm-tracing/src/formatters/blockscout.rs
+++ b/client/evm-tracing/src/formatters/blockscout.rs
@@ -1,0 +1,92 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::listeners::call_list::Listener;
+use crate::types::serialization::*;
+use crate::types::{
+	single::{Call, TransactionTrace},
+	CallResult, CallType, CreateResult,
+};
+use codec::{Decode, Encode};
+use ethereum_types::{H160, U256};
+use serde::Serialize;
+
+pub struct Formatter;
+
+impl super::ResponseFormatter for Formatter {
+	type Listener = Listener;
+	type Response = TransactionTrace;
+
+	fn format(listener: Listener) -> Option<TransactionTrace> {
+		if let Some(entry) = listener.entries.last() {
+			return Some(TransactionTrace::CallList(
+				entry
+					.into_iter()
+					.map(|(_, value)| Call::Blockscout(value.clone()))
+					.collect(),
+			));
+		}
+		None
+	}
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum BlockscoutCallInner {
+	Call {
+		#[serde(rename(serialize = "callType"))]
+		/// Type of call.
+		call_type: CallType,
+		to: H160,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		input: Vec<u8>,
+		/// "output" or "error" field
+		#[serde(flatten)]
+		res: CallResult,
+	},
+	Create {
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		init: Vec<u8>,
+		#[serde(flatten)]
+		res: CreateResult,
+	},
+	SelfDestruct {
+		#[serde(skip)]
+		balance: U256,
+		to: H160,
+	},
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockscoutCall {
+	pub from: H160,
+	/// Indices of parent calls.
+	pub trace_address: Vec<u32>,
+	/// Number of children calls.
+	/// Not needed for Blockscout, but needed for `crate::block`
+	/// types that are build from this type.
+	#[serde(skip)]
+	pub subtraces: u32,
+	/// Sends funds to the (payable) function
+	pub value: U256,
+	/// Remaining gas in the runtime.
+	pub gas: U256,
+	/// Gas used by this context.
+	pub gas_used: U256,
+	#[serde(flatten)]
+	pub inner: BlockscoutCallInner,
+}

--- a/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/evm-tracing/src/formatters/call_tracer.rs
@@ -1,0 +1,306 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::blockscout::BlockscoutCallInner;
+use crate::types::{
+	single::{Call, TransactionTrace},
+	CallResult, CallType, CreateResult,
+};
+
+use crate::listeners::call_list::Listener;
+
+use crate::types::serialization::*;
+use serde::Serialize;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H160, U256};
+use sp_std::{cmp::Ordering, vec::Vec};
+
+pub struct Formatter;
+
+impl super::ResponseFormatter for Formatter {
+	type Listener = Listener;
+	type Response = Vec<TransactionTrace>;
+
+	fn format(mut listener: Listener) -> Option<Vec<TransactionTrace>> {
+		// Remove empty BTreeMaps pushed to `entries`.
+		// I.e. InvalidNonce or other pallet_evm::runner exits
+		listener.entries.retain(|x| !x.is_empty());
+		let mut traces = Vec::new();
+		for entry in listener.entries.iter() {
+			let mut result: Vec<Call> = entry
+				.into_iter()
+				.filter_map(|(_, it)| {
+					let from = it.from;
+					let trace_address = it.trace_address.clone();
+					let value = it.value;
+					let gas = it.gas;
+					let gas_used = it.gas_used;
+					let inner = it.inner.clone();
+					Some(Call::CallTracer(CallTracerCall {
+						from: from,
+						gas: gas,
+						gas_used: gas_used,
+						trace_address: Some(trace_address.clone()),
+						inner: match inner.clone() {
+							BlockscoutCallInner::Call {
+								input,
+								to,
+								res,
+								call_type,
+							} => CallTracerInner::Call {
+								call_type: match call_type {
+									CallType::Call => "CALL".as_bytes().to_vec(),
+									CallType::CallCode => "CALLCODE".as_bytes().to_vec(),
+									CallType::DelegateCall => "DELEGATECALL".as_bytes().to_vec(),
+									CallType::StaticCall => "STATICCALL".as_bytes().to_vec(),
+								},
+								to,
+								input,
+								res,
+								value: Some(value),
+							},
+							BlockscoutCallInner::Create { init, res } => CallTracerInner::Create {
+								input: init,
+								error: match res {
+									CreateResult::Success { .. } => None,
+									CreateResult::Error { ref error } => Some(error.clone()),
+								},
+								to: match res {
+									CreateResult::Success {
+										created_contract_address_hash,
+										..
+									} => Some(created_contract_address_hash),
+									CreateResult::Error { .. } => None,
+								},
+								output: match res {
+									CreateResult::Success {
+										created_contract_code,
+										..
+									} => Some(created_contract_code),
+									CreateResult::Error { .. } => None,
+								},
+								value: value,
+								call_type: "CREATE".as_bytes().to_vec(),
+							},
+							BlockscoutCallInner::SelfDestruct { balance, to } => {
+								CallTracerInner::SelfDestruct {
+									value: balance,
+									to,
+									call_type: "SELFDESTRUCT".as_bytes().to_vec(),
+								}
+							}
+						},
+						calls: Vec::new(),
+					}))
+				})
+				.map(|x| x)
+				.collect();
+			// Geth's `callTracer` expects a tree of nested calls and we have a stack.
+			//
+			// We iterate over the sorted stack, and push each children to it's
+			// parent (the item which's `trace_address` matches &T[0..T.len()-1]) until there
+			// is a single item on the list.
+			//
+			// The last remaining item is the context call with all it's descendants. I.e.
+			//
+			// 		# Input
+			// 		[]
+			// 		[0]
+			// 		[0,0]
+			// 		[0,0,0]
+			// 		[0,1]
+			// 		[0,1,0]
+			// 		[0,1,1]
+			// 		[0,1,2]
+			// 		[1]
+			// 		[1,0]
+			//
+			// 		# Sorted
+			// 		[0,0,0] -> pop 0 and push to [0,0]
+			// 		[0,1,0] -> pop 0 and push to [0,1]
+			// 		[0,1,1] -> pop 1 and push to [0,1]
+			// 		[0,1,2] -> pop 2 and push to [0,1]
+			// 		[0,0] -> pop 0 and push to [0]
+			// 		[0,1] -> pop 1 and push to [0]
+			// 		[1,0] -> pop 0 and push to [1]
+			// 		[0] -> pop 0 and push to root
+			// 		[1] -> pop 1 and push to root
+			// 		[]
+			//
+			// 		# Result
+			// 		root {
+			// 			calls: {
+			// 				0 { 0 { 0 }, 1 { 0, 1, 2 }},
+			// 				1 { 0 },
+			// 			}
+			// 		}
+			if result.len() > 1 {
+				// Sort the stack. Assume there is no `Ordering::Equal`, as we are
+				// sorting by index.
+				//
+				// We consider an item to be `Ordering::Less` when:
+				// 	- Is closer to the root or
+				//	- Is greater than its sibling.
+				result.sort_by(|a, b| match (a, b) {
+					(
+						Call::CallTracer(CallTracerCall {
+							trace_address: Some(a),
+							..
+						}),
+						Call::CallTracer(CallTracerCall {
+							trace_address: Some(b),
+							..
+						}),
+					) => {
+						let a_len = a.len();
+						let b_len = b.len();
+						let sibling_greater_than = |a: &Vec<u32>, b: &Vec<u32>| -> bool {
+							for (i, a_value) in a.iter().enumerate() {
+								if a_value > &b[i] {
+									return true;
+								} else if a_value < &b[i] {
+									return false;
+								} else {
+									continue;
+								}
+							}
+							return false;
+						};
+						if b_len > a_len || (a_len == b_len && sibling_greater_than(&a, &b)) {
+							Ordering::Less
+						} else {
+							Ordering::Greater
+						}
+					}
+					_ => unreachable!(),
+				});
+				// Stack pop-and-push.
+				while result.len() > 1 {
+					let mut last = result.pop().unwrap();
+					// Find the parent index.
+					if let Some(index) =
+						result
+							.iter()
+							.position(|current| match (last.clone(), current) {
+								(
+									Call::CallTracer(CallTracerCall {
+										trace_address: Some(a),
+										..
+									}),
+									Call::CallTracer(CallTracerCall {
+										trace_address: Some(b),
+										..
+									}),
+								) => &b[..] == &a[0..a.len() - 1],
+								_ => unreachable!(),
+							}) {
+						// Remove `trace_address` from result.
+						if let Call::CallTracer(CallTracerCall {
+							ref mut trace_address,
+							..
+						}) = last
+						{
+							*trace_address = None;
+						}
+						// Push the children to parent.
+						if let Some(Call::CallTracer(CallTracerCall { calls, .. })) =
+							result.get_mut(index)
+						{
+							calls.push(last);
+						}
+					}
+				}
+			}
+			// Remove `trace_address` from result.
+			if let Some(Call::CallTracer(CallTracerCall { trace_address, .. })) = result.get_mut(0)
+			{
+				*trace_address = None;
+			}
+			if result.len() == 1 {
+				traces.push(TransactionTrace::CallListNested(result.pop().unwrap()));
+			}
+		}
+		if traces.is_empty() {
+			return None;
+		}
+		return Some(traces);
+	}
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallTracerCall {
+	pub from: H160,
+
+	/// Indices of parent calls. Used to build the Etherscan nested response.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub trace_address: Option<Vec<u32>>,
+
+	/// Remaining gas in the runtime.
+	pub gas: U256,
+	/// Gas used by this context.
+	pub gas_used: U256,
+
+	#[serde(flatten)]
+	pub inner: CallTracerInner,
+
+	#[serde(skip_serializing_if = "Vec::is_empty")]
+	pub calls: Vec<Call>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(untagged)]
+pub enum CallTracerInner {
+	Call {
+		#[serde(rename = "type", serialize_with = "opcode_serialize")]
+		call_type: Vec<u8>,
+		to: H160,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		input: Vec<u8>,
+		/// "output" or "error" field
+		#[serde(flatten)]
+		res: CallResult,
+
+		#[serde(skip_serializing_if = "Option::is_none")]
+		value: Option<U256>,
+	},
+	Create {
+		#[serde(rename = "type", serialize_with = "opcode_serialize")]
+		call_type: Vec<u8>,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		input: Vec<u8>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		to: Option<H160>,
+		#[serde(
+			skip_serializing_if = "Option::is_none",
+			serialize_with = "option_bytes_0x_serialize"
+		)]
+		output: Option<Vec<u8>>,
+		#[serde(
+			skip_serializing_if = "Option::is_none",
+			serialize_with = "option_string_serialize"
+		)]
+		error: Option<Vec<u8>>,
+		value: U256,
+	},
+	SelfDestruct {
+		#[serde(rename = "type", serialize_with = "opcode_serialize")]
+		call_type: Vec<u8>,
+		to: H160,
+		value: U256,
+	},
+}

--- a/client/evm-tracing/src/formatters/mod.rs
+++ b/client/evm-tracing/src/formatters/mod.rs
@@ -1,0 +1,35 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod blockscout;
+pub mod call_tracer;
+pub mod raw;
+pub mod trace_filter;
+
+pub use blockscout::Formatter as Blockscout;
+pub use call_tracer::Formatter as CallTracer;
+pub use raw::Formatter as Raw;
+pub use trace_filter::Formatter as TraceFilter;
+
+use evm_tracing_events::Listener;
+use serde::Serialize;
+
+pub trait ResponseFormatter {
+	type Listener: Listener;
+	type Response: Serialize;
+
+	fn format(listener: Self::Listener) -> Option<Self::Response>;
+}

--- a/client/evm-tracing/src/formatters/raw.rs
+++ b/client/evm-tracing/src/formatters/raw.rs
@@ -1,0 +1,33 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::listeners::raw::Listener;
+use crate::types::single::TransactionTrace;
+
+pub struct Formatter;
+
+impl super::ResponseFormatter for Formatter {
+	type Listener = Listener;
+	type Response = TransactionTrace;
+
+	fn format(listener: Listener) -> Option<TransactionTrace> {
+		Some(TransactionTrace::Raw {
+			step_logs: listener.step_logs,
+			gas: listener.final_gas.into(),
+			return_value: listener.return_value,
+		})
+	}
+}

--- a/client/evm-tracing/src/formatters/trace_filter.rs
+++ b/client/evm-tracing/src/formatters/trace_filter.rs
@@ -1,0 +1,134 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::blockscout::BlockscoutCallInner as CallInner;
+use crate::listeners::call_list::Listener;
+use crate::types::{
+	block::{
+		TransactionTrace, TransactionTraceAction, TransactionTraceOutput, TransactionTraceResult,
+	},
+	CallResult, CreateResult, CreateType,
+};
+use ethereum_types::H256;
+
+pub struct Formatter;
+
+impl super::ResponseFormatter for Formatter {
+	type Listener = Listener;
+	type Response = Vec<TransactionTrace>;
+
+	fn format(mut listener: Listener) -> Option<Vec<TransactionTrace>> {
+		// Remove empty BTreeMaps pushed to `entries`.
+		// I.e. InvalidNonce or other pallet_evm::runner exits
+		listener.entries.retain(|x| !x.is_empty());
+		let mut traces = Vec::new();
+		for (eth_tx_index, entry) in listener.entries.iter().enumerate() {
+			let mut tx_traces: Vec<_> = entry
+				.into_iter()
+				.map(|(_, trace)| match trace.inner.clone() {
+					CallInner::Call {
+						input,
+						to,
+						res,
+						call_type,
+					} => TransactionTrace {
+						action: TransactionTraceAction::Call {
+							call_type,
+							from: trace.from,
+							gas: trace.gas,
+							input,
+							to,
+							value: trace.value,
+						},
+						// Can't be known here, must be inserted upstream.
+						block_hash: H256::default(),
+						// Can't be known here, must be inserted upstream.
+						block_number: 0,
+						output: match res {
+							CallResult::Output(output) => {
+								TransactionTraceOutput::Result(TransactionTraceResult::Call {
+									gas_used: trace.gas_used,
+									output,
+								})
+							}
+							CallResult::Error(error) => TransactionTraceOutput::Error(error),
+						},
+						subtraces: trace.subtraces,
+						trace_address: trace.trace_address.clone(),
+						// Can't be known here, must be inserted upstream.
+						transaction_hash: H256::default(),
+						transaction_position: eth_tx_index as u32,
+					},
+					CallInner::Create { init, res } => {
+						TransactionTrace {
+							action: TransactionTraceAction::Create {
+								creation_method: CreateType::Create,
+								from: trace.from,
+								gas: trace.gas,
+								init,
+								value: trace.value,
+							},
+							// Can't be known here, must be inserted upstream.
+							block_hash: H256::default(),
+							// Can't be known here, must be inserted upstream.
+							block_number: 0,
+							output: match res {
+								CreateResult::Success {
+									created_contract_address_hash,
+									created_contract_code,
+								} => {
+									TransactionTraceOutput::Result(TransactionTraceResult::Create {
+										gas_used: trace.gas_used,
+										code: created_contract_code,
+										address: created_contract_address_hash,
+									})
+								}
+								CreateResult::Error { error } => {
+									TransactionTraceOutput::Error(error)
+								}
+							},
+							subtraces: trace.subtraces,
+							trace_address: trace.trace_address.clone(),
+							// Can't be known here, must be inserted upstream.
+							transaction_hash: H256::default(),
+							transaction_position: eth_tx_index as u32,
+						}
+					}
+					CallInner::SelfDestruct { balance, to } => TransactionTrace {
+						action: TransactionTraceAction::Suicide {
+							address: trace.from,
+							balance,
+							refund_address: to,
+						},
+						// Can't be known here, must be inserted upstream.
+						block_hash: H256::default(),
+						// Can't be known here, must be inserted upstream.
+						block_number: 0,
+						output: TransactionTraceOutput::Result(TransactionTraceResult::Suicide),
+						subtraces: trace.subtraces,
+						trace_address: trace.trace_address.clone(),
+						// Can't be known here, must be inserted upstream.
+						transaction_hash: H256::default(),
+						transaction_position: eth_tx_index as u32,
+					},
+				})
+				.collect();
+
+			traces.append(&mut tx_traces);
+		}
+		Some(traces)
+	}
+}

--- a/client/evm-tracing/src/lib.rs
+++ b/client/evm-tracing/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! This crate contains the client-side part that interacts with our "v2" tracing design.
+
+pub mod formatters;
+pub mod listeners;
+pub mod types;

--- a/client/evm-tracing/src/listeners/call_list.rs
+++ b/client/evm-tracing/src/listeners/call_list.rs
@@ -1,0 +1,1114 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::formatters::blockscout::BlockscoutCall as Call;
+use crate::formatters::blockscout::BlockscoutCallInner as CallInner;
+use crate::types::{CallResult, CallType, ContextType, CreateResult};
+use ethereum_types::{H160, U256};
+use evm_tracing_events::{
+	runtime::{Capture, ExitError, ExitReason, ExitSucceed},
+	Event, EvmEvent, GasometerEvent, Listener as ListenerT, RuntimeEvent, StepEventFilter,
+};
+use std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+
+/// Enum of the different "modes" of tracer for multiple runtime versions and
+/// the kind of EVM events that are emitted.
+enum TracingVersion {
+	/// The first event of the transaction is `EvmEvent::TransactX`. It goes along other events
+	/// such as `EvmEvent::Exit`. All contexts should have clear start/end boundaries.
+	EarlyTransact,
+	/// Older version in which the events above didn't existed.
+	/// It means that we cannot rely on those events to perform any task, and must rely only
+	/// on other events.
+	Legacy,
+}
+
+pub struct Listener {
+	/// Version of the tracing.
+	/// Defaults to legacy, and switch to a more modern version if recently added events are
+	/// received.
+	version: TracingVersion,
+
+	// Transaction cost that must be added to the first context cost.
+	transaction_cost: u64,
+
+	// Final logs.
+	pub entries: Vec<BTreeMap<u32, Call>>,
+	// Next index to use.
+	entries_next_index: u32,
+	// Stack of contexts with data to keep between events.
+	context_stack: Vec<Context>,
+
+	// Type of the next call.
+	// By default is None and corresponds to the root call, which
+	// can be determined using the `is_static` field of the `Call` event.
+	// Then by looking at call traps events we can set this value to the correct
+	// call type, to be used when the following `Call` event is received.
+	call_type: Option<CallType>,
+
+	/// When `EvmEvent::TransactX` is received it creates its own context. However it will usually
+	/// be followed by an `EvmEvent::Call/Create` that will also create a context, which must be
+	/// prevented. It must however not be skipped if `EvmEvent::TransactX` was not received
+	/// (in legacy mode).
+	skip_next_context: bool,
+
+	// /// To handle EvmEvent::Exit no emitted by previous runtimes versions,
+	// /// entries are not inserted directly in `self.entries`.
+	// pending_entries: Vec<(u32, Call)>,
+	/// See `RuntimeEvent::StepResult` event explanatioins.
+	step_result_entry: Option<(u32, Call)>,
+
+	/// When tracing a block `Event::CallListNew` is emitted before each Ethereum transaction is
+	/// processed. Since we use that event to **finish** the transaction, we must ignore the first
+	/// one.
+	call_list_first_transaction: bool,
+
+	/// True if only the `GasometerEvent::RecordTransaction` event has been received.
+	/// Allow to correctly handle transactions that cannot pay for the tx data in Legacy mode.
+	record_transaction_event_only: bool,
+}
+
+struct Context {
+	entries_index: u32,
+
+	context_type: ContextType,
+
+	from: H160,
+	trace_address: Vec<u32>,
+	subtraces: u32,
+	value: U256,
+
+	gas: u64,
+	start_gas: Option<u64>,
+
+	// input / data
+	data: Vec<u8>,
+	// to / create address
+	to: H160,
+}
+
+impl Default for Listener {
+	fn default() -> Self {
+		Self {
+			version: TracingVersion::Legacy,
+			transaction_cost: 0,
+
+			entries: vec![],
+			entries_next_index: 0,
+
+			context_stack: vec![],
+
+			call_type: None,
+			step_result_entry: None,
+			skip_next_context: false,
+			call_list_first_transaction: true,
+			record_transaction_event_only: false,
+		}
+	}
+}
+
+impl Listener {
+	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) -> R {
+		evm_tracing_events::using(self, f)
+	}
+
+	/// Called at the end of each transaction when tracing.
+	/// Allow to insert the pending entries regardless of which runtime version
+	/// is used (with or without EvmEvent::Exit).
+	pub fn finish_transaction(&mut self) {
+		// remove any leftover context
+		let mut context_stack = vec![];
+		core::mem::swap(&mut self.context_stack, &mut context_stack);
+
+		// if there is a left over there have been an early exit.
+		// we generate an entry from it and discord any inner context.
+		if let Some(context) = context_stack.into_iter().next() {
+			let mut gas_used = context.start_gas.unwrap_or(0) - context.gas;
+			if context.entries_index == 0 {
+				gas_used += self.transaction_cost;
+			}
+
+			let entry = match context.context_type {
+				ContextType::Call(call_type) => {
+					let res = CallResult::Error(
+						b"early exit (out of gas, stack overflow, direct call to precompile, ...)"
+							.to_vec(),
+					);
+					Call {
+						from: context.from,
+						trace_address: context.trace_address,
+						subtraces: context.subtraces,
+						value: context.value,
+						gas: context.gas.into(),
+						gas_used: gas_used.into(),
+						inner: CallInner::Call {
+							call_type,
+							to: context.to,
+							input: context.data,
+							res,
+						},
+					}
+				}
+				ContextType::Create => {
+					let res = CreateResult::Error {
+							error: b"early exit (out of gas, stack overflow, direct call to precompile, ...)".to_vec(),
+						};
+
+					Call {
+						value: context.value,
+						trace_address: context.trace_address,
+						subtraces: context.subtraces,
+						gas: context.gas.into(),
+						gas_used: gas_used.into(),
+						from: context.from,
+						inner: CallInner::Create {
+							init: context.data,
+							res,
+						},
+					}
+				}
+			};
+
+			self.insert_entry(context.entries_index, entry);
+			// Since only this context/entry is kept, we need update entries_next_index too.
+			self.entries_next_index = context.entries_index + 1;
+		}
+		// However if the transaction had a too low gas limit to pay for the data cost itself,
+		// and `EvmEvent::Exit` is not emitted in **Legacy mode**, then it has never produced any
+		// context (and exited **early in the transaction**).
+		else if self.record_transaction_event_only {
+			let res = CallResult::Error(
+				b"transaction could not pay its own data cost (impossible to gather more info)"
+					.to_vec(),
+			);
+
+			let entry = Call {
+				from: H160::repeat_byte(0),
+				trace_address: vec![],
+				subtraces: 0,
+				value: 0.into(),
+				gas: 0.into(),
+				gas_used: 0.into(),
+				inner: CallInner::Call {
+					call_type: CallType::Call,
+					to: H160::repeat_byte(0),
+					input: vec![],
+					res,
+				},
+			};
+
+			self.insert_entry(self.entries_next_index, entry);
+			self.entries_next_index += 1;
+		}
+	}
+
+	pub fn gasometer_event(&mut self, event: GasometerEvent) {
+		match event {
+			GasometerEvent::RecordCost { snapshot, .. }
+			| GasometerEvent::RecordDynamicCost { snapshot, .. }
+			| GasometerEvent::RecordStipend { snapshot, .. } => {
+				if let Some(context) = self.context_stack.last_mut() {
+					if context.start_gas.is_none() {
+						context.start_gas = Some(snapshot.gas());
+					}
+					context.gas = snapshot.gas();
+				}
+			}
+			GasometerEvent::RecordTransaction { cost, .. } => {
+				self.transaction_cost = cost;
+				self.record_transaction_event_only = true;
+			}
+			// We ignore other kinds of message if any (new ones may be added in the future).
+			#[allow(unreachable_patterns)]
+			_ => (),
+		}
+	}
+
+	pub fn runtime_event(&mut self, event: RuntimeEvent) {
+		match event {
+			RuntimeEvent::StepResult {
+				result: Err(Capture::Trap(opcode)),
+				..
+			} => {
+				if let Some(ContextType::Call(call_type)) = ContextType::from(opcode) {
+					self.call_type = Some(call_type)
+				}
+			}
+			RuntimeEvent::StepResult {
+				result: Err(Capture::Exit(reason)),
+				return_value,
+			} => {
+				if let Some((key, entry)) = self.pop_context_to_entry(reason, return_value) {
+					match self.version {
+						TracingVersion::Legacy => {
+							// In Legacy mode we directly insert the entry.
+							self.insert_entry(key, entry);
+						}
+						TracingVersion::EarlyTransact => {
+							// In EarlyTransact mode this context must be used if this event is
+							// emitted. However the context of `EvmEvent::Exit` must be used if
+							// `StepResult` is skipped. For that reason we store this generated
+							// entry in a temporary value, and deal with it in `EvmEvent::Exit` that
+							// will be called in all cases.
+							self.step_result_entry = Some((key, entry));
+						}
+					}
+				}
+			}
+			// We ignore other kinds of message if any (new ones may be added in the future).
+			#[allow(unreachable_patterns)]
+			_ => (),
+		}
+	}
+
+	pub fn evm_event(&mut self, event: EvmEvent) {
+		match event {
+			EvmEvent::TransactCall {
+				caller,
+				address,
+				value,
+				data,
+				..
+			} => {
+				self.record_transaction_event_only = false;
+				self.version = TracingVersion::EarlyTransact;
+				self.context_stack.push(Context {
+					entries_index: self.entries_next_index,
+
+					context_type: ContextType::Call(CallType::Call),
+
+					from: caller,
+					trace_address: vec![],
+					subtraces: 0,
+					value,
+
+					gas: 0,
+					start_gas: None,
+
+					data,
+					to: address,
+				});
+
+				self.entries_next_index += 1;
+				self.skip_next_context = true;
+			}
+
+			EvmEvent::TransactCreate {
+				caller,
+				value,
+				init_code,
+				address,
+				..
+			} => {
+				self.record_transaction_event_only = false;
+				self.version = TracingVersion::EarlyTransact;
+				self.context_stack.push(Context {
+					entries_index: self.entries_next_index,
+
+					context_type: ContextType::Create,
+
+					from: caller,
+					trace_address: vec![],
+					subtraces: 0,
+					value,
+
+					gas: 0,
+					start_gas: None,
+
+					data: init_code,
+					to: address,
+				});
+
+				self.entries_next_index += 1;
+				self.skip_next_context = true;
+			}
+
+			EvmEvent::TransactCreate2 {
+				caller,
+				value,
+				init_code,
+				address,
+				..
+			} => {
+				self.record_transaction_event_only = false;
+				self.version = TracingVersion::EarlyTransact;
+				self.context_stack.push(Context {
+					entries_index: self.entries_next_index,
+
+					context_type: ContextType::Create,
+
+					from: caller,
+					trace_address: vec![],
+					subtraces: 0,
+					value,
+
+					gas: 0,
+					start_gas: None,
+
+					data: init_code,
+					to: address,
+				});
+
+				self.entries_next_index += 1;
+				self.skip_next_context = true;
+			}
+
+			EvmEvent::Call {
+				input,
+				is_static,
+				context,
+				..
+			} => {
+				self.record_transaction_event_only = false;
+
+				let call_type = match (self.call_type, is_static) {
+					(None, true) => CallType::StaticCall,
+					(None, false) => CallType::Call,
+					(Some(call_type), _) => call_type,
+				};
+
+				if !self.skip_next_context {
+					let trace_address = if let Some(context) = self.context_stack.last_mut() {
+						let mut trace_address = context.trace_address.clone();
+						trace_address.push(context.subtraces);
+						context.subtraces += 1;
+						trace_address
+					} else {
+						vec![]
+					};
+
+					self.context_stack.push(Context {
+						entries_index: self.entries_next_index,
+
+						context_type: ContextType::Call(call_type),
+
+						from: context.caller,
+						trace_address,
+						subtraces: 0,
+						value: context.apparent_value,
+
+						gas: 0,
+						start_gas: None,
+
+						data: input.to_vec(),
+						to: context.address,
+					});
+
+					self.entries_next_index += 1;
+				} else {
+					self.skip_next_context = false;
+				}
+			}
+
+			EvmEvent::Create {
+				caller,
+				address,
+				// scheme,
+				value,
+				init_code,
+				..
+			} => {
+				self.record_transaction_event_only = false;
+
+				if !self.skip_next_context {
+					let trace_address = if let Some(context) = self.context_stack.last_mut() {
+						let mut trace_address = context.trace_address.clone();
+						trace_address.push(context.subtraces);
+						context.subtraces += 1;
+						trace_address
+					} else {
+						vec![]
+					};
+
+					self.context_stack.push(Context {
+						entries_index: self.entries_next_index,
+
+						context_type: ContextType::Create,
+
+						from: caller,
+						trace_address,
+						subtraces: 0,
+						value,
+
+						gas: 0,
+						start_gas: None,
+
+						data: init_code.to_vec(),
+						to: address,
+					});
+
+					self.entries_next_index += 1;
+				} else {
+					self.skip_next_context = false;
+				}
+			}
+			EvmEvent::Suicide {
+				address,
+				target,
+				balance,
+			} => {
+				let trace_address = if let Some(context) = self.context_stack.last_mut() {
+					let mut trace_address = context.trace_address.clone();
+					trace_address.push(context.subtraces);
+					context.subtraces += 1;
+					trace_address
+				} else {
+					vec![]
+				};
+
+				if self.entries.is_empty() {
+					self.entries.push(BTreeMap::new());
+				}
+				self.entries.last_mut().unwrap().insert(
+					self.entries_next_index,
+					Call {
+						from: address, // this contract is self destructing
+						trace_address,
+						subtraces: 0,
+						value: 0.into(),
+						gas: 0.into(),
+						gas_used: 0.into(),
+						inner: CallInner::SelfDestruct {
+							to: target,
+							balance,
+						},
+					},
+				);
+				self.entries_next_index += 1;
+			}
+			EvmEvent::Exit {
+				reason,
+				return_value,
+			} => {
+				// We know we're in `TracingVersion::EarlyTransact` mode.
+
+				self.record_transaction_event_only = false;
+
+				let entry = self
+					.step_result_entry
+					.take()
+					.or_else(|| self.pop_context_to_entry(reason, return_value));
+
+				if let Some((key, entry)) = entry {
+					self.insert_entry(key, entry);
+				}
+			}
+			// We ignore other kinds of message if any (new ones may be added in the future).
+			#[allow(unreachable_patterns)]
+			_ => (),
+		}
+	}
+
+	fn insert_entry(&mut self, key: u32, entry: Call) {
+		if self.entries.is_empty() {
+			self.entries.push(BTreeMap::new());
+		}
+
+		self.entries.last_mut().unwrap().insert(key, entry);
+	}
+
+	fn pop_context_to_entry(
+		&mut self,
+		reason: ExitReason,
+		return_value: Vec<u8>,
+	) -> Option<(u32, Call)> {
+		if let Some(context) = self.context_stack.pop() {
+			let mut gas_used = context.start_gas.unwrap_or(0) - context.gas;
+			if context.entries_index == 0 {
+				gas_used += self.transaction_cost;
+			}
+
+			Some((
+				context.entries_index,
+				match context.context_type {
+					ContextType::Call(call_type) => {
+						let res = match &reason {
+							ExitReason::Succeed(ExitSucceed::Returned) => {
+								CallResult::Output(return_value.to_vec())
+							}
+							ExitReason::Succeed(_) => CallResult::Output(vec![]),
+							ExitReason::Error(error) => CallResult::Error(error_message(error)),
+
+							ExitReason::Revert(_) => {
+								CallResult::Error(b"execution reverted".to_vec())
+							}
+							ExitReason::Fatal(_) => CallResult::Error(vec![]),
+						};
+
+						Call {
+							from: context.from,
+							trace_address: context.trace_address,
+							subtraces: context.subtraces,
+							value: context.value,
+							gas: context.gas.into(),
+							gas_used: gas_used.into(),
+							inner: CallInner::Call {
+								call_type,
+								to: context.to,
+								input: context.data,
+								res,
+							},
+						}
+					}
+					ContextType::Create => {
+						let res = match &reason {
+							ExitReason::Succeed(_) => CreateResult::Success {
+								created_contract_address_hash: context.to,
+								created_contract_code: return_value.to_vec(),
+							},
+							ExitReason::Error(error) => CreateResult::Error {
+								error: error_message(error),
+							},
+							ExitReason::Revert(_) => CreateResult::Error {
+								error: b"execution reverted".to_vec(),
+							},
+							ExitReason::Fatal(_) => CreateResult::Error { error: vec![] },
+						};
+
+						Call {
+							value: context.value,
+							trace_address: context.trace_address,
+							subtraces: context.subtraces,
+							gas: context.gas.into(),
+							gas_used: gas_used.into(),
+							from: context.from,
+							inner: CallInner::Create {
+								init: context.data,
+								res,
+							},
+						}
+					}
+				},
+			))
+		} else {
+			None
+		}
+	}
+}
+
+fn error_message(error: &ExitError) -> Vec<u8> {
+	match error {
+		ExitError::StackUnderflow => "stack underflow",
+		ExitError::StackOverflow => "stack overflow",
+		ExitError::InvalidJump => "invalid jump",
+		ExitError::InvalidRange => "invalid range",
+		ExitError::DesignatedInvalid => "designated invalid",
+		ExitError::CallTooDeep => "call too deep",
+		ExitError::CreateCollision => "create collision",
+		ExitError::CreateContractLimit => "create contract limit",
+		ExitError::OutOfOffset => "out of offset",
+		ExitError::OutOfGas => "out of gas",
+		ExitError::OutOfFund => "out of funds",
+		ExitError::Other(err) => err,
+		_ => "unexpected error",
+	}
+	.as_bytes()
+	.to_vec()
+}
+
+impl ListenerT for Listener {
+	fn event(&mut self, event: Event) {
+		match event {
+			Event::Gasometer(gasometer_event) => self.gasometer_event(gasometer_event),
+			Event::Runtime(runtime_event) => self.runtime_event(runtime_event),
+			Event::Evm(evm_event) => self.evm_event(evm_event),
+			Event::CallListNew() => {
+				if !self.call_list_first_transaction {
+					self.finish_transaction();
+					self.skip_next_context = false;
+					self.entries.push(BTreeMap::new());
+				} else {
+					self.call_list_first_transaction = false;
+				}
+			}
+		};
+	}
+
+	fn step_event_filter(&self) -> StepEventFilter {
+		StepEventFilter {
+			enable_memory: false,
+			enable_stack: false,
+		}
+	}
+}
+
+#[cfg(test)]
+#[allow(unused)]
+mod tests {
+	use super::*;
+	use ethereum_types::H256;
+	use evm_tracing_events::{
+		evm::CreateScheme,
+		gasometer::Snapshot,
+		runtime::{Memory, Stack},
+		Context as EvmContext,
+	};
+
+	enum TestEvmEvent {
+		Call,
+		Create,
+		Suicide,
+		Exit,
+		TransactCall,
+		TransactCreate,
+		TransactCreate2,
+	}
+
+	enum TestRuntimeEvent {
+		Step,
+		StepResult,
+		SLoad,
+		SStore,
+	}
+
+	enum TestGasometerEvent {
+		RecordCost,
+		RecordRefund,
+		RecordStipend,
+		RecordDynamicCost,
+		RecordTransaction,
+	}
+
+	fn test_context() -> EvmContext {
+		EvmContext {
+			address: H160::default(),
+			caller: H160::default(),
+			apparent_value: U256::zero(),
+		}
+	}
+
+	fn test_create_scheme() -> CreateScheme {
+		CreateScheme::Legacy {
+			caller: H160::default(),
+		}
+	}
+
+	fn test_stack() -> Option<Stack> {
+		None
+	}
+
+	fn test_memory() -> Option<Memory> {
+		None
+	}
+
+	fn test_snapshot() -> Snapshot {
+		Snapshot {
+			gas_limit: 0u64,
+			memory_gas: 0u64,
+			used_gas: 0u64,
+			refunded_gas: 0i64,
+		}
+	}
+
+	fn test_emit_evm_event(
+		event_type: TestEvmEvent,
+		is_static: bool,
+		exit_reason: Option<ExitReason>,
+	) -> EvmEvent {
+		match event_type {
+			TestEvmEvent::Call => EvmEvent::Call {
+				code_address: H160::default(),
+				transfer: None,
+				input: Vec::new(),
+				target_gas: None,
+				is_static,
+				context: test_context(),
+			},
+			TestEvmEvent::Create => EvmEvent::Create {
+				caller: H160::default(),
+				address: H160::default(),
+				scheme: test_create_scheme(),
+				value: U256::zero(),
+				init_code: Vec::new(),
+				target_gas: None,
+			},
+			TestEvmEvent::Suicide => EvmEvent::Suicide {
+				address: H160::default(),
+				target: H160::default(),
+				balance: U256::zero(),
+			},
+			TestEvmEvent::Exit => EvmEvent::Exit {
+				reason: exit_reason.unwrap(),
+				return_value: Vec::new(),
+			},
+			TestEvmEvent::TransactCall => EvmEvent::TransactCall {
+				caller: H160::default(),
+				address: H160::default(),
+				value: U256::zero(),
+				data: Vec::new(),
+				gas_limit: 0u64,
+			},
+			TestEvmEvent::TransactCreate => EvmEvent::TransactCreate {
+				caller: H160::default(),
+				value: U256::zero(),
+				init_code: Vec::new(),
+				gas_limit: 0u64,
+				address: H160::default(),
+			},
+			TestEvmEvent::TransactCreate2 => EvmEvent::TransactCreate2 {
+				caller: H160::default(),
+				value: U256::zero(),
+				init_code: Vec::new(),
+				salt: H256::default(),
+				gas_limit: 0u64,
+				address: H160::default(),
+			},
+		}
+	}
+
+	fn test_emit_runtime_event(event_type: TestRuntimeEvent) -> RuntimeEvent {
+		match event_type {
+			TestRuntimeEvent::Step => RuntimeEvent::Step {
+				context: test_context(),
+				opcode: Vec::new(),
+				position: Ok(0u64),
+				stack: test_stack(),
+				memory: test_memory(),
+			},
+			TestRuntimeEvent::StepResult => RuntimeEvent::StepResult {
+				result: Ok(()),
+				return_value: Vec::new(),
+			},
+			TestRuntimeEvent::SLoad => RuntimeEvent::SLoad {
+				address: H160::default(),
+				index: H256::default(),
+				value: H256::default(),
+			},
+			TestRuntimeEvent::SStore => RuntimeEvent::SStore {
+				address: H160::default(),
+				index: H256::default(),
+				value: H256::default(),
+			},
+		}
+	}
+
+	fn test_emit_gasometer_event(event_type: TestGasometerEvent) -> GasometerEvent {
+		match event_type {
+			TestGasometerEvent::RecordCost => GasometerEvent::RecordCost {
+				cost: 0u64,
+				snapshot: test_snapshot(),
+			},
+			TestGasometerEvent::RecordRefund => GasometerEvent::RecordRefund {
+				refund: 0i64,
+				snapshot: test_snapshot(),
+			},
+			TestGasometerEvent::RecordStipend => GasometerEvent::RecordStipend {
+				stipend: 0u64,
+				snapshot: test_snapshot(),
+			},
+			TestGasometerEvent::RecordDynamicCost => GasometerEvent::RecordDynamicCost {
+				gas_cost: 0u64,
+				memory_gas: 0u64,
+				gas_refund: 0i64,
+				snapshot: test_snapshot(),
+			},
+			TestGasometerEvent::RecordTransaction => GasometerEvent::RecordTransaction {
+				cost: 0u64,
+				snapshot: test_snapshot(),
+			},
+		}
+	}
+
+	fn do_transact_call_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(TestEvmEvent::TransactCall, false, None));
+	}
+
+	fn do_transact_create_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(
+			TestEvmEvent::TransactCreate,
+			false,
+			None,
+		));
+	}
+
+	fn do_gasometer_event(listener: &mut Listener) {
+		listener.gasometer_event(test_emit_gasometer_event(
+			TestGasometerEvent::RecordTransaction,
+		));
+	}
+
+	fn do_exit_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(
+			TestEvmEvent::Exit,
+			false,
+			Some(ExitReason::Error(ExitError::OutOfGas)),
+		));
+	}
+
+	fn do_evm_call_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(TestEvmEvent::Call, false, None));
+	}
+
+	fn do_evm_create_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(TestEvmEvent::Create, false, None));
+	}
+
+	fn do_evm_suicide_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(TestEvmEvent::Suicide, false, None));
+	}
+
+	fn do_runtime_step_event(listener: &mut Listener) {
+		listener.runtime_event(test_emit_runtime_event(TestRuntimeEvent::Step));
+	}
+
+	fn do_runtime_step_result_event(listener: &mut Listener) {
+		listener.runtime_event(test_emit_runtime_event(TestRuntimeEvent::StepResult));
+	}
+
+	// Call context
+
+	// Early exit on TransactionCost.
+	#[test]
+	fn call_early_exit_tx_cost() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Early exit somewhere between the first callstack event and stepping the bytecode.
+	// I.e. precompile call.
+	#[test]
+	fn call_early_exit_before_runtime() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Exit after Step without StepResult.
+	#[test]
+	fn call_step_without_step_result() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Exit after StepResult.
+	#[test]
+	fn call_step_result() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Suicide.
+	#[test]
+	fn call_suicide() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_evm_suicide_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 2);
+	}
+
+	// Create context
+
+	// Early exit on TransactionCost.
+	#[test]
+	fn create_early_exit_tx_cost() {
+		let mut listener = Listener::default();
+		do_transact_create_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Early exit somewhere between the first callstack event and stepping the bytecode
+	// I.e. precompile call..
+	#[test]
+	fn create_early_exit_before_runtime() {
+		let mut listener = Listener::default();
+		do_transact_create_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_create_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Exit after Step without StepResult.
+	#[test]
+	fn create_step_without_step_result() {
+		let mut listener = Listener::default();
+		do_transact_create_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_create_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Exit after StepResult.
+	#[test]
+	fn create_step_result() {
+		let mut listener = Listener::default();
+		do_transact_create_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_create_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Call Context Nested
+
+	// Nested call early exit before stepping.
+	#[test]
+	fn nested_call_early_exit_before_runtime() {
+		let mut listener = Listener::default();
+		// Main
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		// Nested
+		do_evm_call_event(&mut listener);
+		do_exit_event(&mut listener);
+		// Main exit
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 2);
+	}
+
+	// Nested exit before step result.
+	#[test]
+	fn nested_call_without_step_result() {
+		let mut listener = Listener::default();
+		// Main
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		// Nested
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_exit_event(&mut listener);
+		// Main exit
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 2);
+	}
+
+	// Nested exit.
+	#[test]
+	fn nested_call_step_result() {
+		let depth = 5;
+		let mut listener = Listener::default();
+		// Main
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		// 5 nested calls
+		for d in 0..depth {
+			do_evm_call_event(&mut listener);
+			do_runtime_step_event(&mut listener);
+			do_runtime_step_result_event(&mut listener);
+			do_exit_event(&mut listener);
+		}
+		// Main exit
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), depth + 1);
+	}
+
+	// Call + Create mixed subnesting.
+
+	#[test]
+	fn subnested_call_and_create_mixbag() {
+		let depth = 5;
+		let subdepth = 10;
+		let mut listener = Listener::default();
+		// Main
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_runtime_step_result_event(&mut listener);
+		// 5 nested call/creates, each with 10 nested call/creates
+		for d in 0..depth {
+			if d % 2 == 0 {
+				do_evm_call_event(&mut listener);
+			} else {
+				do_evm_create_event(&mut listener);
+			}
+			do_runtime_step_event(&mut listener);
+			do_runtime_step_result_event(&mut listener);
+			for s in 0..subdepth {
+				// Some mixed call/create and early exits.
+				if s % 2 == 0 {
+					do_evm_call_event(&mut listener);
+				} else {
+					do_evm_create_event(&mut listener);
+				}
+				if s % 3 == 0 {
+					do_runtime_step_event(&mut listener);
+					do_runtime_step_result_event(&mut listener);
+				}
+				do_exit_event(&mut listener);
+			}
+			// Nested exit
+			do_exit_event(&mut listener);
+		}
+		// Main exit
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		// Each nested call contains 11 elements in the callstack (main + 10 subcalls).
+		// There are 5 main nested calls for a total of 56 elements in the callstack: 1 main + 55 nested.
+		assert_eq!(listener.entries[0].len(), (depth * (subdepth + 1)) + 1);
+	}
+}

--- a/client/evm-tracing/src/listeners/mod.rs
+++ b/client/evm-tracing/src/listeners/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod call_list;
+pub mod raw;
+
+pub use call_list::Listener as CallList;
+pub use raw::Listener as Raw;

--- a/client/evm-tracing/src/listeners/raw.rs
+++ b/client/evm-tracing/src/listeners/raw.rs
@@ -1,0 +1,309 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::{H160, H256};
+use std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+
+use crate::types::{convert_memory, single::RawStepLog, ContextType};
+use evm_tracing_events::{
+	runtime::{Capture, ExitReason},
+	Event, GasometerEvent, Listener as ListenerT, RuntimeEvent, StepEventFilter,
+};
+
+#[derive(Debug)]
+pub struct Listener {
+	disable_storage: bool,
+	disable_memory: bool,
+	disable_stack: bool,
+
+	new_context: bool,
+	context_stack: Vec<Context>,
+
+	pub step_logs: Vec<RawStepLog>,
+	pub return_value: Vec<u8>,
+	pub final_gas: u64,
+}
+
+#[derive(Debug)]
+struct Context {
+	storage_cache: BTreeMap<H256, H256>,
+	address: H160,
+	current_step: Option<Step>,
+	global_storage_changes: BTreeMap<H160, BTreeMap<H256, H256>>,
+}
+
+#[derive(Debug)]
+struct Step {
+	/// Current opcode.
+	opcode: Vec<u8>,
+	/// Depth of the context.
+	depth: usize,
+	/// Remaining gas.
+	gas: u64,
+	/// Gas cost of the following opcode.
+	gas_cost: u64,
+	/// Program counter position.
+	position: usize,
+	/// EVM memory copy (if not disabled).
+	memory: Option<Vec<u8>>,
+	/// EVM stack copy (if not disabled).
+	stack: Option<Vec<H256>>,
+}
+
+impl Listener {
+	pub fn new(disable_storage: bool, disable_memory: bool, disable_stack: bool) -> Self {
+		Self {
+			disable_storage,
+			disable_memory,
+			disable_stack,
+
+			step_logs: vec![],
+			return_value: vec![],
+			final_gas: 0,
+
+			new_context: false,
+			context_stack: vec![],
+		}
+	}
+
+	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) -> R {
+		evm_tracing_events::using(self, f)
+	}
+
+	pub fn gasometer_event(&mut self, event: GasometerEvent) {
+		match event {
+			GasometerEvent::RecordTransaction { cost, .. } => {
+				// First event of a transaction.
+				// Next step will be the first context.
+				self.new_context = true;
+				self.final_gas = cost;
+			}
+			GasometerEvent::RecordCost { cost, snapshot } => {
+				if let Some(context) = self.context_stack.last_mut() {
+					// Register opcode cost. (ignore costs not between Step and StepResult)
+					if let Some(step) = &mut context.current_step {
+						step.gas = snapshot.gas();
+						step.gas_cost = cost;
+					}
+
+					self.final_gas = snapshot.used_gas;
+				}
+			}
+			GasometerEvent::RecordDynamicCost {
+				gas_cost, snapshot, ..
+			} => {
+				if let Some(context) = self.context_stack.last_mut() {
+					// Register opcode cost. (ignore costs not between Step and StepResult)
+					if let Some(step) = &mut context.current_step {
+						step.gas = snapshot.gas();
+						step.gas_cost = gas_cost;
+					}
+
+					self.final_gas = snapshot.used_gas;
+				}
+			}
+			// We ignore other kinds of message if any (new ones may be added in the future).
+			#[allow(unreachable_patterns)]
+			_ => (),
+		}
+	}
+
+	pub fn runtime_event(&mut self, event: RuntimeEvent) {
+		match event {
+			RuntimeEvent::Step {
+				context,
+				opcode,
+				position,
+				stack,
+				memory,
+			} => {
+				// Create a context if needed.
+				if self.new_context {
+					self.new_context = false;
+
+					self.context_stack.push(Context {
+						storage_cache: BTreeMap::new(),
+						address: context.address,
+						current_step: None,
+						global_storage_changes: BTreeMap::new(),
+					});
+				}
+
+				let depth = self.context_stack.len();
+
+				// Ignore steps outside of any context (shouldn't even be possible).
+				if let Some(context) = self.context_stack.last_mut() {
+					context.current_step = Some(Step {
+						opcode,
+						depth,
+						gas: 0,      // 0 for now, will add with gas events
+						gas_cost: 0, // 0 for now, will add with gas events
+						position: *position.as_ref().unwrap_or(&0) as usize,
+						memory: if self.disable_memory {
+							None
+						} else {
+							Some(
+								memory
+									.expect("memory data to not be filtered out")
+									.data
+									.clone(),
+							)
+						},
+						stack: if self.disable_stack {
+							None
+						} else {
+							Some(
+								stack
+									.expect("stack data to not be filtered out")
+									.data
+									.clone(),
+							)
+						},
+					});
+				}
+			}
+			RuntimeEvent::StepResult {
+				result,
+				return_value,
+			} => {
+				// StepResult is expected to be emited after a step (in a context).
+				// Only case StepResult will occur without a Step before is in a transfer
+				// transaction to a non-contract address. However it will not contain any
+				// steps and return an empty trace, so we can ignore this edge case.
+				if let Some(context) = self.context_stack.last_mut() {
+					if let Some(current_step) = context.current_step.take() {
+						let Step {
+							opcode,
+							depth,
+							gas,
+							gas_cost,
+							position,
+							memory,
+							stack,
+						} = current_step;
+
+						let memory = memory.map(convert_memory);
+
+						let storage = if self.disable_storage {
+							None
+						} else {
+							Some(context.storage_cache.clone())
+						};
+
+						self.step_logs.push(RawStepLog {
+							depth: depth.into(),
+							gas: gas.into(),
+							gas_cost: gas_cost.into(),
+							memory,
+							op: opcode,
+							pc: position.into(),
+							stack,
+							storage,
+						});
+					}
+				}
+
+				// We match on the capture to handle traps/exits.
+				match result {
+					Err(Capture::Exit(reason)) => {
+						// Exit = we exit the context (should always be some)
+						if let Some(mut context) = self.context_stack.pop() {
+							// If final context is exited, we store gas and return value.
+							if self.context_stack.is_empty() {
+								self.return_value = return_value.to_vec();
+							}
+
+							// If the context exited without revert we must keep track of the
+							// updated storage keys.
+							if !self.disable_storage && matches!(reason, ExitReason::Succeed(_)) {
+								if let Some(parent_context) = self.context_stack.last_mut() {
+									// Add cache to storage changes.
+									context
+										.global_storage_changes
+										.insert(context.address, context.storage_cache);
+
+									// Apply storage changes to parent, either updating its cache or map of changes.
+									for (address, mut storage) in
+										context.global_storage_changes.into_iter()
+									{
+										// Same address => We update its cache (only tracked keys)
+										if parent_context.address == address {
+											for (cached_key, cached_value) in
+												parent_context.storage_cache.iter_mut()
+											{
+												if let Some(value) = storage.remove(cached_key) {
+													*cached_value = value;
+												}
+											}
+										}
+										// Otherwise, update the storage changes.
+										else {
+											parent_context
+												.global_storage_changes
+												.entry(address)
+												.or_insert_with(BTreeMap::new)
+												.append(&mut storage);
+										}
+									}
+								}
+							}
+						}
+					}
+					Err(Capture::Trap(opcode)) if ContextType::from(opcode.clone()).is_some() => {
+						self.new_context = true;
+					}
+					_ => (),
+				}
+			}
+			RuntimeEvent::SLoad {
+				address: _,
+				index,
+				value,
+			}
+			| RuntimeEvent::SStore {
+				address: _,
+				index,
+				value,
+			} => {
+				if let Some(context) = self.context_stack.last_mut() {
+					if !self.disable_storage {
+						context.storage_cache.insert(index, value);
+					}
+				}
+			}
+			// We ignore other kinds of message if any (new ones may be added in the future).
+			#[allow(unreachable_patterns)]
+			_ => (),
+		}
+	}
+}
+
+impl ListenerT for Listener {
+	fn event(&mut self, event: Event) {
+		match event {
+			Event::Gasometer(e) => self.gasometer_event(e),
+			Event::Runtime(e) => self.runtime_event(e),
+			_ => {}
+		};
+	}
+
+	fn step_event_filter(&self) -> StepEventFilter {
+		StepEventFilter {
+			enable_memory: !self.disable_memory,
+			enable_stack: !self.disable_stack,
+		}
+	}
+}

--- a/client/evm-tracing/src/types/block.rs
+++ b/client/evm-tracing/src/types/block.rs
@@ -1,0 +1,97 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Types for tracing all Ethereum transactions of a block.
+
+use super::serialization::*;
+use serde::Serialize;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H160, H256, U256};
+use sp_std::vec::Vec;
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionTrace {
+	#[serde(flatten)]
+	pub action: TransactionTraceAction,
+	#[serde(serialize_with = "h256_0x_serialize")]
+	pub block_hash: H256,
+	pub block_number: u32,
+	#[serde(flatten)]
+	pub output: TransactionTraceOutput,
+	pub subtraces: u32,
+	pub trace_address: Vec<u32>,
+	#[serde(serialize_with = "h256_0x_serialize")]
+	pub transaction_hash: H256,
+	pub transaction_position: u32,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type", content = "action")]
+pub enum TransactionTraceAction {
+	#[serde(rename_all = "camelCase")]
+	Call {
+		call_type: super::CallType,
+		from: H160,
+		gas: U256,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		input: Vec<u8>,
+		to: H160,
+		value: U256,
+	},
+	#[serde(rename_all = "camelCase")]
+	Create {
+		creation_method: super::CreateType,
+		from: H160,
+		gas: U256,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		init: Vec<u8>,
+		value: U256,
+	},
+	#[serde(rename_all = "camelCase")]
+	Suicide {
+		address: H160,
+		balance: U256,
+		refund_address: H160,
+	},
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionTraceOutput {
+	Result(TransactionTraceResult),
+	Error(#[serde(serialize_with = "string_serialize")] Vec<u8>),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum TransactionTraceResult {
+	#[serde(rename_all = "camelCase")]
+	Call {
+		gas_used: U256,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		output: Vec<u8>,
+	},
+	#[serde(rename_all = "camelCase")]
+	Create {
+		address: H160,
+		#[serde(serialize_with = "bytes_0x_serialize")]
+		code: Vec<u8>,
+		gas_used: U256,
+	},
+	Suicide,
+}

--- a/client/evm-tracing/src/types/mod.rs
+++ b/client/evm-tracing/src/types/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Runtime API allowing to debug/trace Ethereum
+
+extern crate alloc;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H160, H256};
+use sp_std::vec::Vec;
+
+pub mod block;
+pub mod serialization;
+pub mod single;
+
+use serde::Serialize;
+use serialization::*;
+
+pub const MANUAL_BLOCK_INITIALIZATION_RUNTIME_VERSION: u32 = 159;
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CallResult {
+	Output(#[serde(serialize_with = "bytes_0x_serialize")] Vec<u8>),
+	// field "error"
+	Error(#[serde(serialize_with = "string_serialize")] Vec<u8>),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum CreateResult {
+	Error {
+		#[serde(serialize_with = "string_serialize")]
+		error: Vec<u8>,
+	},
+	Success {
+		#[serde(rename = "createdContractAddressHash")]
+		created_contract_address_hash: H160,
+		#[serde(serialize_with = "bytes_0x_serialize", rename = "createdContractCode")]
+		created_contract_code: Vec<u8>,
+	},
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CallType {
+	Call,
+	CallCode,
+	DelegateCall,
+	StaticCall,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CreateType {
+	Create,
+}
+
+#[derive(Debug)]
+pub enum ContextType {
+	Call(CallType),
+	Create,
+}
+
+impl ContextType {
+	pub fn from(opcode: Vec<u8>) -> Option<Self> {
+		let opcode = match alloc::str::from_utf8(&opcode[..]) {
+			Ok(op) => op.to_uppercase(),
+			_ => return None,
+		};
+		match &opcode[..] {
+			"CREATE" | "CREATE2" => Some(ContextType::Create),
+			"CALL" => Some(ContextType::Call(CallType::Call)),
+			"CALLCODE" => Some(ContextType::Call(CallType::CallCode)),
+			"DELEGATECALL" => Some(ContextType::Call(CallType::DelegateCall)),
+			"STATICCALL" => Some(ContextType::Call(CallType::StaticCall)),
+			_ => None,
+		}
+	}
+}
+
+pub fn convert_memory(memory: Vec<u8>) -> Vec<H256> {
+	let size = 32;
+	memory
+		.chunks(size)
+		.map(|c| {
+			let mut msg = [0u8; 32];
+			let chunk = c.len();
+			if chunk < size {
+				let left = size - chunk;
+				let remainder = vec![0; left];
+				msg[0..left].copy_from_slice(&remainder[..]);
+				msg[left..size].copy_from_slice(c);
+			} else {
+				msg[0..size].copy_from_slice(c)
+			}
+			H256::from_slice(&msg[..])
+		})
+		.collect()
+}

--- a/client/evm-tracing/src/types/serialization.rs
+++ b/client/evm-tracing/src/types/serialization.rs
@@ -1,0 +1,109 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Provide serialization functions for various types and formats.
+
+use ethereum_types::{H256, U256};
+use serde::{
+	ser::{Error, SerializeSeq},
+	Serializer,
+};
+
+pub fn seq_h256_serialize<S>(data: &Option<Vec<H256>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	let d = data.clone().unwrap();
+	let mut seq = serializer.serialize_seq(Some(d.len()))?;
+	for h in d {
+		seq.serialize_element(&format!("{:x}", h))?;
+	}
+	seq.end()
+}
+
+pub fn bytes_0x_serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{}", hex::encode(bytes)))
+}
+
+pub fn option_bytes_0x_serialize<S>(
+	bytes: &Option<Vec<u8>>,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	if let Some(bytes) = bytes.as_ref() {
+		return serializer.serialize_str(&format!("0x{}", hex::encode(&bytes[..])));
+	}
+	Err(S::Error::custom("String serialize error."))
+}
+
+pub fn opcode_serialize<S>(opcode: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	let d = std::str::from_utf8(opcode)
+		.map_err(|_| S::Error::custom("Opcode serialize error."))?
+		.to_uppercase();
+	serializer.serialize_str(&d)
+}
+
+pub fn string_serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	let d = std::str::from_utf8(value)
+		.map_err(|_| S::Error::custom("String serialize error."))?
+		.to_string();
+	serializer.serialize_str(&d)
+}
+
+pub fn option_string_serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	if let Some(value) = value.as_ref() {
+		let d = std::str::from_utf8(&value[..])
+			.map_err(|_| S::Error::custom("String serialize error."))?
+			.to_string();
+		return serializer.serialize_str(&d);
+	}
+	Err(S::Error::custom("String serialize error."))
+}
+
+pub fn u256_serialize<S>(data: &U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_u64(data.low_u64())
+}
+
+pub fn h256_serialize<S>(data: &H256, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("{:x}", data))
+}
+
+pub fn h256_0x_serialize<S>(data: &H256, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{:x}", data))
+}

--- a/client/evm-tracing/src/types/single.rs
+++ b/client/evm-tracing/src/types/single.rs
@@ -1,0 +1,102 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Types for the tracing of a single Ethereum transaction.
+//! Structure from "raw" debug_trace and a "call list" matching
+//! Blockscout formatter. This "call list" is also used to build
+//! the whole block tracing output.
+
+use super::serialization::*;
+use serde::Serialize;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H256, U256};
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum Call {
+	Blockscout(crate::formatters::blockscout::BlockscoutCall),
+	CallTracer(crate::formatters::call_tracer::CallTracerCall),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode)]
+pub enum TraceType {
+	/// Classic geth with no javascript based tracing.
+	Raw {
+		disable_storage: bool,
+		disable_memory: bool,
+		disable_stack: bool,
+	},
+	/// List of calls and subcalls formatted with an input tracer (i.e. callTracer or Blockscout).
+	CallList,
+	/// A single block trace. Use in `debug_traceTransactionByNumber` / `traceTransactionByHash`.
+	Block,
+}
+
+/// Single transaction trace.
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum TransactionTrace {
+	/// Classical output of `debug_trace`.
+	#[serde(rename_all = "camelCase")]
+	Raw {
+		gas: U256,
+		#[serde(with = "hex")]
+		return_value: Vec<u8>,
+		step_logs: Vec<RawStepLog>,
+	},
+	/// Matches the formatter used by Blockscout.
+	/// Is also used to built output of OpenEthereum's `trace_filter`.
+	CallList(Vec<Call>),
+	/// Used by Geth's callTracer.
+	CallListNested(Call),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawStepLog {
+	#[serde(serialize_with = "u256_serialize")]
+	pub depth: U256,
+
+	//error: TODO
+	#[serde(serialize_with = "u256_serialize")]
+	pub gas: U256,
+
+	#[serde(serialize_with = "u256_serialize")]
+	pub gas_cost: U256,
+
+	#[serde(
+		serialize_with = "seq_h256_serialize",
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub memory: Option<Vec<H256>>,
+
+	#[serde(serialize_with = "opcode_serialize")]
+	pub op: Vec<u8>,
+
+	#[serde(serialize_with = "u256_serialize")]
+	pub pc: U256,
+
+	#[serde(
+		serialize_with = "seq_h256_serialize",
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub stack: Option<Vec<H256>>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub storage: Option<BTreeMap<H256, H256>>,
+}

--- a/client/rpc-core/debug/Cargo.toml
+++ b/client/rpc-core/debug/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "peaq-rpc-core-debug"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+ethereum-types = "0.12.1"
+futures = { version = "0.3", features = [ "compat" ] }
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+peaq-client-evm-tracing = { path = "../../evm-tracing" }
+peaq-rpc-core-types = { path = "../types" }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"
+
+sp-core = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }

--- a/client/rpc-core/debug/Cargo.toml
+++ b/client/rpc-core/debug/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-core-debug"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/client/rpc-core/debug/src/lib.rs
+++ b/client/rpc-core/debug/src/lib.rs
@@ -1,0 +1,51 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+use ethereum_types::H256;
+use futures::future::BoxFuture;
+use jsonrpc_core::Result as RpcResult;
+use jsonrpc_derive::rpc;
+use peaq_client_evm_tracing::types::single;
+use peaq_rpc_core_types::RequestBlockId;
+use serde::Deserialize;
+
+pub use rpc_impl_Debug::gen_server::Debug as DebugServer;
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceParams {
+	pub disable_storage: Option<bool>,
+	pub disable_memory: Option<bool>,
+	pub disable_stack: Option<bool>,
+	/// Javascript tracer (we just check if it's Blockscout tracer string)
+	pub tracer: Option<String>,
+	pub timeout: Option<String>,
+}
+
+#[rpc(server)]
+pub trait Debug {
+	#[rpc(name = "debug_traceTransaction")]
+	fn trace_transaction(
+		&self,
+		transaction_hash: H256,
+		params: Option<TraceParams>,
+	) -> BoxFuture<'static, RpcResult<single::TransactionTrace>>;
+	#[rpc(name = "debug_traceBlockByNumber", alias("debug_traceBlockByHash"))]
+	fn trace_block(
+		&self,
+		id: RequestBlockId,
+		params: Option<TraceParams>,
+	) -> BoxFuture<'static, RpcResult<Vec<single::TransactionTrace>>>;
+}

--- a/client/rpc-core/trace/Cargo.toml
+++ b/client/rpc-core/trace/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "peaq-rpc-core-trace"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.6.0"
+
+[dependencies]
+ethereum-types = "0.12.1"
+futures = { version = "0.3.1", features = [ "compat" ] }
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+peaq-client-evm-tracing = { path = "../../evm-tracing" }
+peaq-rpc-core-types = { path = "../types" }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"

--- a/client/rpc-core/trace/Cargo.toml
+++ b/client/rpc-core/trace/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-core-trace"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/client/rpc-core/trace/src/lib.rs
+++ b/client/rpc-core/trace/src/lib.rs
@@ -1,0 +1,55 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::H160;
+use futures::future::BoxFuture;
+use jsonrpc_derive::rpc;
+use peaq_client_evm_tracing::types::block::TransactionTrace;
+use peaq_rpc_core_types::RequestBlockId;
+use serde::Deserialize;
+
+pub use rpc_impl_Trace::gen_server::Trace as TraceServer;
+
+#[rpc(server)]
+pub trait Trace {
+	#[rpc(name = "trace_filter")]
+	fn filter(
+		&self,
+		filter: FilterRequest,
+	) -> BoxFuture<'static, jsonrpc_core::Result<Vec<TransactionTrace>>>;
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterRequest {
+	/// (optional?) From this block.
+	pub from_block: Option<RequestBlockId>,
+
+	/// (optional?) To this block.
+	pub to_block: Option<RequestBlockId>,
+
+	/// (optional) Sent from these addresses.
+	pub from_address: Option<Vec<H160>>,
+
+	/// (optional) Sent to these addresses.
+	pub to_address: Option<Vec<H160>>,
+
+	/// (optional) The offset trace number
+	pub after: Option<u32>,
+
+	/// (optional) Integer number of traces to display in a batch.
+	pub count: Option<u32>,
+}

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "peaq-rpc-core-txpool"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.6.0"
+
+[dependencies]
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+ethereum-types = "0.12.1"
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"
+
+fc-rpc-core = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-core-txpool"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/client/rpc-core/txpool/src/lib.rs
+++ b/client/rpc-core/txpool/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::U256;
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+mod types;
+
+pub use crate::types::{Get as GetT, Summary, Transaction, TransactionMap, TxPoolResult};
+
+pub use rpc_impl_TxPool::gen_server::TxPool as TxPoolServer;
+
+#[rpc(server)]
+pub trait TxPool {
+	#[rpc(name = "txpool_content")]
+	fn content(&self) -> Result<TxPoolResult<TransactionMap<Transaction>>>;
+
+	#[rpc(name = "txpool_inspect")]
+	fn inspect(&self) -> Result<TxPoolResult<TransactionMap<Summary>>>;
+
+	#[rpc(name = "txpool_status")]
+	fn status(&self) -> Result<TxPoolResult<U256>>;
+}

--- a/client/rpc-core/txpool/src/types/content.rs
+++ b/client/rpc-core/txpool/src/types/content.rs
@@ -1,0 +1,111 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::GetT;
+use ethereum::{TransactionAction, TransactionV2 as EthereumTransaction};
+use ethereum_types::{H160, H256, U256};
+use fc_rpc_core::types::Bytes;
+use serde::{Serialize, Serializer};
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+	/// Hash
+	pub hash: H256,
+	/// Nonce
+	pub nonce: U256,
+	/// Block hash
+	#[serde(serialize_with = "block_hash_serialize")]
+	pub block_hash: Option<H256>,
+	/// Block number
+	pub block_number: Option<U256>,
+	/// Sender
+	pub from: H160,
+	/// Recipient
+	#[serde(serialize_with = "to_serialize")]
+	pub to: Option<H160>,
+	/// Transfered value
+	pub value: U256,
+	/// Gas Price
+	pub gas_price: U256,
+	/// Gas
+	pub gas: U256,
+	/// Data
+	pub input: Bytes,
+	/// Transaction Index
+	pub transaction_index: Option<U256>,
+}
+
+fn block_hash_serialize<S>(hash: &Option<H256>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{:x}", hash.unwrap_or_default()))
+}
+
+fn to_serialize<S>(hash: &Option<H160>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	serializer.serialize_str(&format!("0x{:x}", hash.unwrap_or_default()))
+}
+
+impl GetT for Transaction {
+	fn get(hash: H256, from_address: H160, txn: &EthereumTransaction) -> Self {
+		let (nonce, action, value, gas_price, gas_limit, input) = match txn {
+			EthereumTransaction::Legacy(t) => (
+				t.nonce,
+				t.action,
+				t.value,
+				t.gas_price,
+				t.gas_limit,
+				t.input.clone(),
+			),
+			EthereumTransaction::EIP2930(t) => (
+				t.nonce,
+				t.action,
+				t.value,
+				t.gas_price,
+				t.gas_limit,
+				t.input.clone(),
+			),
+			EthereumTransaction::EIP1559(t) => (
+				t.nonce,
+				t.action,
+				t.value,
+				t.max_fee_per_gas,
+				t.gas_limit,
+				t.input.clone(),
+			),
+		};
+		Self {
+			hash,
+			nonce,
+			block_hash: None,
+			block_number: None,
+			from: from_address,
+			to: match action {
+				TransactionAction::Call(to) => Some(to),
+				_ => None,
+			},
+			value,
+			gas_price,
+			gas: gas_limit,
+			input: Bytes(input),
+			transaction_index: None,
+		}
+	}
+}

--- a/client/rpc-core/txpool/src/types/inspect.rs
+++ b/client/rpc-core/txpool/src/types/inspect.rs
@@ -1,0 +1,63 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::GetT;
+use ethereum::{TransactionAction, TransactionV2 as EthereumTransaction};
+use ethereum_types::{H160, H256, U256};
+use serde::{Serialize, Serializer};
+
+#[derive(Clone, Debug)]
+pub struct Summary {
+	pub to: Option<H160>,
+	pub value: U256,
+	pub gas: U256,
+	pub gas_price: U256,
+}
+
+impl Serialize for Summary {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let res = format!(
+			"0x{:x}: {} wei + {} gas x {} wei",
+			self.to.unwrap_or_default(),
+			self.value,
+			self.gas,
+			self.gas_price
+		);
+		serializer.serialize_str(&res)
+	}
+}
+
+impl GetT for Summary {
+	fn get(_hash: H256, _from_address: H160, txn: &EthereumTransaction) -> Self {
+		let (action, value, gas_price, gas_limit) = match txn {
+			EthereumTransaction::Legacy(t) => (t.action, t.value, t.gas_price, t.gas_limit),
+			EthereumTransaction::EIP2930(t) => (t.action, t.value, t.gas_price, t.gas_limit),
+			EthereumTransaction::EIP1559(t) => (t.action, t.value, t.max_fee_per_gas, t.gas_limit),
+		};
+		Self {
+			to: match action {
+				TransactionAction::Call(to) => Some(to),
+				_ => None,
+			},
+			value,
+			gas_price,
+			gas: gas_limit,
+		}
+	}
+}

--- a/client/rpc-core/txpool/src/types/mod.rs
+++ b/client/rpc-core/txpool/src/types/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+mod content;
+mod inspect;
+
+use ethereum::TransactionV2 as EthereumTransaction;
+use ethereum_types::{H160, H256, U256};
+use serde::Serialize;
+use std::collections::HashMap;
+
+pub use self::content::Transaction;
+pub use self::inspect::Summary;
+
+pub type TransactionMap<T> = HashMap<H160, HashMap<U256, T>>;
+
+#[derive(Debug, Serialize)]
+pub struct TxPoolResult<T: Serialize> {
+	pub pending: T,
+	pub queued: T,
+}
+
+pub trait Get {
+	fn get(hash: H256, from_address: H160, txn: &EthereumTransaction) -> Self;
+}

--- a/client/rpc-core/types/Cargo.toml
+++ b/client/rpc-core/types/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-core-types"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/client/rpc-core/types/Cargo.toml
+++ b/client/rpc-core/types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "peaq-rpc-core-types"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+ethereum-types = "0.12.1"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"

--- a/client/rpc-core/types/src/lib.rs
+++ b/client/rpc-core/types/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright 2019-2022 PureStake Inc..
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::H256;
+use serde::{de::Error, Deserialize, Deserializer};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum RequestBlockId {
+	Number(#[serde(deserialize_with = "deserialize_u32_0x")] u32),
+	Hash(H256),
+	Tag(RequestBlockTag),
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RequestBlockTag {
+	Earliest,
+	Latest,
+	Pending,
+}
+
+fn deserialize_u32_0x<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let buf = String::deserialize(deserializer)?;
+
+	let parsed = match buf.strip_prefix("0x") {
+		Some(buf) => u32::from_str_radix(&buf, 16),
+		None => u32::from_str_radix(&buf, 10),
+	};
+
+	parsed.map_err(|e| Error::custom(format!("parsing error: {:?} from '{}'", e, buf)))
+}

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-debug"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "peaq-rpc-debug"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+futures = { version = "0.3", features = [ "compat" ] }
+hex-literal = "0.3.4"
+jsonrpc-core = "18.0.0"
+tokio = { version = "1.10", features = [ "sync", "time" ] }
+
+peaq-client-evm-tracing = { path = "../../evm-tracing" }
+peaq-rpc-core-debug = { path = "../../rpc-core/debug" }
+peaq-rpc-core-types = { path = "../../rpc-core/types" }
+peaq-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
+
+# Substrate
+sc-client-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sc-utils = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-block-builder = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-blockchain = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-core = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-io = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+
+# Frontier
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+ethereum-types = "0.12.1"
+fc-consensus = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }
+fc-db = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }
+fc-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16", features = [ "rpc_binary_search_estimate" ] }
+fp-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -497,7 +497,10 @@ where
 									trace_api_version, e
 								))
 							})?
-							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
+							.map_err(|e| {
+								panic!("Invalid enum value");
+								internal_err(format!("DispatchError: {:?}", e))
+							})?;
 					} else {
 						// Pre-london update, legacy transactions.
 						let _result = match transaction {

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -1,0 +1,578 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+use futures::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
+use jsonrpc_core::Result as RpcResult;
+pub use peaq_rpc_core_debug::{Debug as DebugT, DebugServer, TraceParams};
+
+use tokio::{
+	self,
+	sync::{oneshot, Semaphore},
+};
+
+use ethereum_types::H256;
+use fc_rpc::{frontier_backend_client, internal_err, OverrideHandle};
+use fp_rpc::EthereumRuntimeRPCApi;
+use peaq_client_evm_tracing::{formatters::ResponseFormatter, types::single};
+use peaq_rpc_core_types::{RequestBlockId, RequestBlockTag};
+use peaq_rpc_primitives_debug::{DebugRuntimeApi, TracerInput};
+use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
+use sc_utils::mpsc::TracingUnboundedSender;
+use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::{
+	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
+};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, UniqueSaturatedInto};
+use std::{future::Future, marker::PhantomData, sync::Arc};
+
+pub enum RequesterInput {
+	Transaction(H256),
+	Block(RequestBlockId),
+}
+
+pub enum Response {
+	Single(single::TransactionTrace),
+	Block(Vec<single::TransactionTrace>),
+}
+
+pub type Responder = oneshot::Sender<RpcResult<Response>>;
+pub type DebugRequester =
+	TracingUnboundedSender<((RequesterInput, Option<TraceParams>), Responder)>;
+
+pub struct Debug {
+	pub requester: DebugRequester,
+}
+
+impl Debug {
+	pub fn new(requester: DebugRequester) -> Self {
+		Self { requester }
+	}
+}
+
+impl DebugT for Debug {
+	/// Handler for `debug_traceTransaction` request. Communicates with the service-defined task
+	/// using channels.
+	fn trace_transaction(
+		&self,
+		transaction_hash: H256,
+		params: Option<TraceParams>,
+	) -> BoxFuture<'static, RpcResult<single::TransactionTrace>> {
+		let mut requester = self.requester.clone();
+
+		async move {
+			let (tx, rx) = oneshot::channel();
+			// Send a message from the rpc handler to the service level task.
+			requester
+				.send(((RequesterInput::Transaction(transaction_hash), params), tx))
+				.await
+				.map_err(|err| {
+					internal_err(format!(
+						"failed to send request to debug service : {:?}",
+						err
+					))
+				})?;
+
+			// Receive a message from the service level task and send the rpc response.
+			rx.await
+				.map_err(|err| {
+					internal_err(format!("debug service dropped the channel : {:?}", err))
+				})?
+				.map(|res| match res {
+					Response::Single(res) => res,
+					_ => unreachable!(),
+				})
+		}
+		.boxed()
+	}
+
+	fn trace_block(
+		&self,
+		id: RequestBlockId,
+		params: Option<TraceParams>,
+	) -> BoxFuture<'static, RpcResult<Vec<single::TransactionTrace>>> {
+		let mut requester = self.requester.clone();
+
+		async move {
+			let (tx, rx) = oneshot::channel();
+			// Send a message from the rpc handler to the service level task.
+			requester
+				.send(((RequesterInput::Block(id), params), tx))
+				.await
+				.map_err(|err| {
+					internal_err(format!(
+						"failed to send request to debug service : {:?}",
+						err
+					))
+				})?;
+
+			// Receive a message from the service level task and send the rpc response.
+			rx.await
+				.map_err(|err| {
+					internal_err(format!("debug service dropped the channel : {:?}", err))
+				})?
+				.map(|res| match res {
+					Response::Block(res) => res,
+					_ => unreachable!(),
+				})
+		}
+		.boxed()
+	}
+}
+
+pub struct DebugHandler<B: BlockT, C, BE>(PhantomData<(B, C, BE)>);
+
+impl<B, C, BE> DebugHandler<B, C, BE>
+where
+	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	C: ProvideRuntimeApi<B>,
+	C: StorageProvider<B, BE>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	C::Api: BlockBuilder<B>,
+	C::Api: DebugRuntimeApi<B>,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	C::Api: ApiExt<B>,
+{
+	/// Task spawned at service level that listens for messages on the rpc channel and spawns
+	/// blocking tasks using a permit pool.
+	pub fn task(
+		client: Arc<C>,
+		backend: Arc<BE>,
+		frontier_backend: Arc<fc_db::Backend<B>>,
+		permit_pool: Arc<Semaphore>,
+		overrides: Arc<OverrideHandle<B>>,
+	) -> (impl Future<Output = ()>, DebugRequester) {
+		let (tx, mut rx): (DebugRequester, _) =
+			sc_utils::mpsc::tracing_unbounded("debug-requester");
+
+		let fut = async move {
+			loop {
+				match rx.next().await {
+					Some((
+						(RequesterInput::Transaction(transaction_hash), params),
+						response_tx,
+					)) => {
+						let client = client.clone();
+						let backend = backend.clone();
+						let frontier_backend = frontier_backend.clone();
+						let permit_pool = permit_pool.clone();
+						let overrides = overrides.clone();
+
+						tokio::task::spawn(async move {
+							let _ = response_tx.send(
+								async {
+									let _permit = permit_pool.acquire().await;
+									tokio::task::spawn_blocking(move || {
+										Self::handle_transaction_request(
+											client.clone(),
+											backend.clone(),
+											frontier_backend.clone(),
+											transaction_hash,
+											params,
+											overrides.clone(),
+										)
+									})
+									.await
+									.map_err(|e| {
+										internal_err(format!(
+											"Internal error on spawned task : {:?}",
+											e
+										))
+									})?
+								}
+								.await,
+							);
+						});
+					}
+					Some(((RequesterInput::Block(request_block_id), params), response_tx)) => {
+						let client = client.clone();
+						let backend = backend.clone();
+						let frontier_backend = frontier_backend.clone();
+						let permit_pool = permit_pool.clone();
+						let overrides = overrides.clone();
+
+						tokio::task::spawn(async move {
+							let _ = response_tx.send(
+								async {
+									let _permit = permit_pool.acquire().await;
+
+									tokio::task::spawn_blocking(move || {
+										Self::handle_block_request(
+											client.clone(),
+											backend.clone(),
+											frontier_backend.clone(),
+											request_block_id,
+											params,
+											overrides.clone(),
+										)
+									})
+									.await
+									.map_err(|e| {
+										internal_err(format!(
+											"Internal error on spawned task : {:?}",
+											e
+										))
+									})?
+								}
+								.await,
+							);
+						});
+					}
+					_ => {}
+				}
+			}
+		};
+		(fut, tx)
+	}
+
+	fn handle_params(params: Option<TraceParams>) -> RpcResult<(TracerInput, single::TraceType)> {
+		// Set trace input and type
+		match params {
+			Some(TraceParams {
+				tracer: Some(tracer),
+				..
+			}) => {
+				const BLOCKSCOUT_JS_CODE_HASH: [u8; 16] =
+					hex_literal::hex!("94d9f08796f91eb13a2e82a6066882f7");
+				const BLOCKSCOUT_JS_CODE_HASH_V2: [u8; 16] =
+					hex_literal::hex!("89db13694675692951673a1e6e18ff02");
+				let hash = sp_io::hashing::twox_128(&tracer.as_bytes());
+				let tracer =
+					if hash == BLOCKSCOUT_JS_CODE_HASH || hash == BLOCKSCOUT_JS_CODE_HASH_V2 {
+						Some(TracerInput::Blockscout)
+					} else if tracer == "callTracer" {
+						Some(TracerInput::CallTracer)
+					} else {
+						None
+					};
+				if let Some(tracer) = tracer {
+					Ok((tracer, single::TraceType::CallList))
+				} else {
+					return Err(internal_err(format!(
+						"javascript based tracing is not available (hash :{:?})",
+						hash
+					)));
+				}
+			}
+			Some(params) => Ok((
+				TracerInput::None,
+				single::TraceType::Raw {
+					disable_storage: params.disable_storage.unwrap_or(false),
+					disable_memory: params.disable_memory.unwrap_or(false),
+					disable_stack: params.disable_stack.unwrap_or(false),
+				},
+			)),
+			_ => Ok((
+				TracerInput::None,
+				single::TraceType::Raw {
+					disable_storage: false,
+					disable_memory: false,
+					disable_stack: false,
+				},
+			)),
+		}
+	}
+
+	fn handle_block_request(
+		client: Arc<C>,
+		backend: Arc<BE>,
+		frontier_backend: Arc<fc_db::Backend<B>>,
+		request_block_id: RequestBlockId,
+		params: Option<TraceParams>,
+		overrides: Arc<OverrideHandle<B>>,
+	) -> RpcResult<Response> {
+		let (tracer_input, trace_type) = Self::handle_params(params)?;
+
+		let reference_id: BlockId<B> = match request_block_id {
+			RequestBlockId::Number(n) => Ok(BlockId::Number(n.unique_saturated_into())),
+			RequestBlockId::Tag(RequestBlockTag::Latest) => {
+				Ok(BlockId::Number(client.info().best_number))
+			}
+			RequestBlockId::Tag(RequestBlockTag::Earliest) => {
+				Ok(BlockId::Number(0u32.unique_saturated_into()))
+			}
+			RequestBlockId::Tag(RequestBlockTag::Pending) => {
+				Err(internal_err("'pending' blocks are not supported"))
+			}
+			RequestBlockId::Hash(eth_hash) => {
+				match frontier_backend_client::load_hash::<B>(frontier_backend.as_ref(), eth_hash) {
+					Ok(Some(id)) => Ok(id),
+					Ok(_) => Err(internal_err("Block hash not found".to_string())),
+					Err(e) => Err(e),
+				}
+			}
+		}?;
+
+		// Get ApiRef. This handle allow to keep changes between txs in an internal buffer.
+		let api = client.runtime_api();
+		// Get Blockchain backend
+		let blockchain = backend.blockchain();
+		// Get the header I want to work with.
+		let header = client.header(reference_id).unwrap().unwrap();
+		// Get parent blockid.
+		let parent_block_id = BlockId::Hash(*header.parent_hash());
+
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			reference_id,
+		);
+
+		// Using storage overrides we align with `:ethereum_schema` which will result in proper
+		// SCALE decoding in case of migration.
+		let statuses = match overrides.schemas.get(&schema) {
+			Some(schema) => schema.current_transaction_statuses(&reference_id),
+			_ => {
+				return Err(internal_err(format!(
+					"No storage override at {:?}",
+					reference_id
+				)))
+			}
+		};
+
+		// Known ethereum transaction hashes.
+		let eth_tx_hashes: Vec<_> = statuses
+			.unwrap()
+			.iter()
+			.map(|t| t.transaction_hash)
+			.collect();
+
+		// If there are no ethereum transactions in the block return empty trace right away.
+		if eth_tx_hashes.is_empty() {
+			return Ok(Response::Block(vec![]));
+		}
+
+		// Get the extrinsics.
+		let ext = blockchain.body(reference_id).unwrap().unwrap();
+
+		// Trace the block.
+		let f = || -> RpcResult<_> {
+			api.initialize_block(&parent_block_id, &header)
+				.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+
+			let _result = api
+				.trace_block(&parent_block_id, ext, eth_tx_hashes)
+				.map_err(|e| {
+					internal_err(format!(
+						"Blockchain error when replaying block {} : {:?}",
+						reference_id, e
+					))
+				})?
+				.map_err(|e| {
+					internal_err(format!(
+						"Internal runtime error when replaying block {} : {:?}",
+						reference_id, e
+					))
+				})?;
+			Ok(peaq_rpc_primitives_debug::Response::Block)
+		};
+
+		return match trace_type {
+			single::TraceType::CallList => {
+				let mut proxy = peaq_client_evm_tracing::listeners::CallList::default();
+				proxy.using(f)?;
+				proxy.finish_transaction();
+				let response = match tracer_input {
+					TracerInput::CallTracer => {
+						peaq_client_evm_tracing::formatters::CallTracer::format(proxy)
+							.ok_or("Trace result is empty.")
+							.map_err(|e| internal_err(format!("{:?}", e)))
+					}
+					_ => Err(internal_err(format!(
+						"Bug: failed to resolve the tracer format."
+					))),
+				}?;
+
+				Ok(Response::Block(response))
+			}
+			not_supported => Err(internal_err(format!(
+				"Bug: `handle_block_request` does not support {:?}.",
+				not_supported
+			))),
+		};
+	}
+
+	/// Replays a transaction in the Runtime at a given block height.
+	///
+	/// In order to succesfully reproduce the result of the original transaction we need a correct
+	/// state to replay over.
+	///
+	/// Substrate allows to apply extrinsics in the Runtime and thus creating an overlayed state.
+	/// This overlayed changes will live in-memory for the lifetime of the ApiRef.
+	fn handle_transaction_request(
+		client: Arc<C>,
+		backend: Arc<BE>,
+		frontier_backend: Arc<fc_db::Backend<B>>,
+		transaction_hash: H256,
+		params: Option<TraceParams>,
+		overrides: Arc<OverrideHandle<B>>,
+	) -> RpcResult<Response> {
+		let (tracer_input, trace_type) = Self::handle_params(params)?;
+
+		let (hash, index) = match frontier_backend_client::load_transactions::<B, C>(
+			client.as_ref(),
+			frontier_backend.as_ref(),
+			transaction_hash,
+			false,
+		) {
+			Ok(Some((hash, index))) => (hash, index as usize),
+			Ok(None) => return Err(internal_err("Transaction hash not found".to_string())),
+			Err(e) => return Err(e),
+		};
+
+		let reference_id =
+			match frontier_backend_client::load_hash::<B>(frontier_backend.as_ref(), hash) {
+				Ok(Some(hash)) => hash,
+				Ok(_) => return Err(internal_err("Block hash not found".to_string())),
+				Err(e) => return Err(e),
+			};
+		// Get ApiRef. This handle allow to keep changes between txs in an internal buffer.
+		let api = client.runtime_api();
+		// Get Blockchain backend
+		let blockchain = backend.blockchain();
+		// Get the header I want to work with.
+		let header = client.header(reference_id).unwrap().unwrap();
+		// Get parent blockid.
+		let parent_block_id = BlockId::Hash(*header.parent_hash());
+
+		// Get the extrinsics.
+		let ext = blockchain.body(reference_id).unwrap().unwrap();
+
+		// Get DebugRuntimeApi version
+		let trace_api_version = if let Ok(Some(api_version)) =
+			api.api_version::<dyn DebugRuntimeApi<B>>(&parent_block_id)
+		{
+			api_version
+		} else {
+			return Err(internal_err(
+				"Runtime api version call failed (trace)".to_string(),
+			));
+		};
+
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			reference_id,
+		);
+
+		// Get the block that contains the requested transaction. Using storage overrides we align
+		// with `:ethereum_schema` which will result in proper SCALE decoding in case of migration.
+		let reference_block = match overrides.schemas.get(&schema) {
+			Some(schema) => schema.current_block(&reference_id),
+			_ => {
+				return Err(internal_err(format!(
+					"No storage override at {:?}",
+					reference_id
+				)))
+			}
+		};
+
+		// Get the actual ethereum transaction.
+		if let Some(block) = reference_block {
+			let transactions = block.transactions;
+			if let Some(transaction) = transactions.get(index) {
+				let f = || -> RpcResult<_> {
+					api.initialize_block(&parent_block_id, &header)
+						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+
+					if trace_api_version >= 4 {
+						let _result = api
+							.trace_transaction(&parent_block_id, ext, &transaction)
+							.map_err(|e| {
+								internal_err(format!(
+									"Runtime api access error (version {:?}): {:?}",
+									trace_api_version, e
+								))
+							})?
+							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
+					} else {
+						// Pre-london update, legacy transactions.
+						let _result = match transaction {
+							ethereum::TransactionV2::Legacy(tx) =>
+							{
+								#[allow(deprecated)]
+								api.trace_transaction_before_version_4(&parent_block_id, ext, &tx)
+									.map_err(|e| {
+										internal_err(format!(
+											"Runtime api access error (legacy): {:?}",
+											e
+										))
+									})?
+									.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?
+							}
+							_ => {
+								return Err(internal_err(
+									"Bug: pre-london runtime expects legacy transactions"
+										.to_string(),
+								))
+							}
+						};
+					}
+
+					Ok(peaq_rpc_primitives_debug::Response::Single)
+				};
+
+				return match trace_type {
+					single::TraceType::Raw {
+						disable_storage,
+						disable_memory,
+						disable_stack,
+					} => {
+						let mut proxy = peaq_client_evm_tracing::listeners::Raw::new(
+							disable_storage,
+							disable_memory,
+							disable_stack,
+						);
+						proxy.using(f)?;
+						Ok(Response::Single(
+							peaq_client_evm_tracing::formatters::Raw::format(proxy).unwrap(),
+						))
+					}
+					single::TraceType::CallList => {
+						let mut proxy = peaq_client_evm_tracing::listeners::CallList::default();
+						proxy.using(f)?;
+						proxy.finish_transaction();
+						let response = match tracer_input {
+							TracerInput::Blockscout => {
+								peaq_client_evm_tracing::formatters::Blockscout::format(proxy)
+									.ok_or("Trace result is empty.")
+									.map_err(|e| internal_err(format!("{:?}", e)))
+							}
+							TracerInput::CallTracer => {
+								let mut res =
+									peaq_client_evm_tracing::formatters::CallTracer::format(
+										proxy,
+									)
+									.ok_or("Trace result is empty.")
+									.map_err(|e| internal_err(format!("{:?}", e)))?;
+								Ok(res.pop().unwrap())
+							}
+							_ => Err(internal_err(format!(
+								"Bug: failed to resolve the tracer format."
+							))),
+						}?;
+						Ok(Response::Single(response))
+					}
+					not_supported => Err(internal_err(format!(
+						"Bug: `handle_transaction_request` does not support {:?}.",
+						not_supported
+					))),
+				};
+			}
+		}
+		Err(internal_err("Runtime block call failed".to_string()))
+	}
+}

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-trace"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "peaq-rpc-trace"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.6.0"
+
+[dependencies]
+ethereum = { version = "0.11.1", features = [ "with-codec" ] }
+ethereum-types = "0.12.1"
+futures = { version = "0.3" }
+jsonrpc-core = "18.0.0"
+serde = { version = "1.0", features = [ "derive" ] }
+sha3 = "0.9"
+tokio = { version = "1.10", features = [ "sync", "time" ] }
+tracing = "0.1.25"
+
+peaq-client-evm-tracing = { path = "../../evm-tracing" }
+peaq-rpc-core-trace = { path = "../../rpc-core/trace" }
+peaq-rpc-core-types = { path = "../../rpc-core/types" }
+peaq-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
+
+# Substrate
+sc-client-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sc-network = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sc-utils = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-block-builder = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-blockchain = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-io = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-transaction-pool = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+
+# Frontier
+fc-consensus = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }
+fc-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16", features = [ "rpc_binary_search_estimate" ] }
+fc-rpc-core = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }
+fp-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16" }

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -1,0 +1,913 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! `trace_filter` RPC handler and its associated service task.
+//! The RPC handler rely on `CacheTask` which provides a future that must be run inside a tokio
+//! executor.
+//!
+//! The implementation is composed of multiple tasks :
+//! - Many calls the the RPC handler `Trace::filter`, communicating with the main task.
+//! - A main `CacheTask` managing the cache and the communication between tasks.
+//! - For each traced block an async task responsible to wait for a permit, spawn a blocking
+//!   task and waiting for the result, then send it to the main `CacheTask`.
+
+use futures::{future::BoxFuture, select, stream::FuturesUnordered, FutureExt, SinkExt, StreamExt};
+use std::{collections::BTreeMap, future::Future, marker::PhantomData, sync::Arc, time::Duration};
+use tokio::{
+	sync::{mpsc, oneshot, Semaphore},
+	time::sleep,
+};
+use tracing::{instrument, Instrument};
+
+use jsonrpc_core::Result;
+use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
+use sc_utils::mpsc::TracingUnboundedSender;
+use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::{
+	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
+};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
+
+use ethereum_types::H256;
+use fc_rpc::{frontier_backend_client, internal_err, OverrideHandle};
+use fp_rpc::EthereumRuntimeRPCApi;
+
+use peaq_client_evm_tracing::{
+	formatters::ResponseFormatter,
+	types::block::{self, TransactionTrace},
+};
+pub use peaq_rpc_core_trace::{FilterRequest, Trace as TraceT, TraceServer};
+use peaq_rpc_core_types::{RequestBlockId, RequestBlockTag};
+use peaq_rpc_primitives_debug::DebugRuntimeApi;
+
+/// RPC handler. Will communicate with a `CacheTask` through a `CacheRequester`.
+pub struct Trace<B, C> {
+	_phantom: PhantomData<B>,
+	client: Arc<C>,
+	requester: CacheRequester,
+	max_count: u32,
+}
+
+impl<B, C> Clone for Trace<B, C> {
+	fn clone(&self) -> Self {
+		Self {
+			_phantom: PhantomData::default(),
+			client: Arc::clone(&self.client),
+			requester: self.requester.clone(),
+			max_count: self.max_count,
+		}
+	}
+}
+
+impl<B, C> Trace<B, C>
+where
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	B::Header: HeaderT<Number = u32>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+{
+	/// Create a new RPC handler.
+	pub fn new(client: Arc<C>, requester: CacheRequester, max_count: u32) -> Self {
+		Self {
+			client,
+			requester,
+			max_count,
+			_phantom: PhantomData::default(),
+		}
+	}
+
+	/// Convert an optional block ID (number or tag) to a block height.
+	fn block_id(&self, id: Option<RequestBlockId>) -> Result<u32> {
+		match id {
+			Some(RequestBlockId::Number(n)) => Ok(n),
+			None | Some(RequestBlockId::Tag(RequestBlockTag::Latest)) => {
+				Ok(self.client.info().best_number)
+			}
+			Some(RequestBlockId::Tag(RequestBlockTag::Earliest)) => Ok(0),
+			Some(RequestBlockId::Tag(RequestBlockTag::Pending)) => {
+				Err(internal_err("'pending' is not supported"))
+			}
+			Some(RequestBlockId::Hash(_)) => Err(internal_err("Block hash not supported")),
+		}
+	}
+
+	/// `trace_filter` endpoint (wrapped in the trait implementation with futures compatibilty)
+	async fn filter(self, req: FilterRequest) -> Result<Vec<TransactionTrace>> {
+		let from_block = self.block_id(req.from_block)?;
+		let to_block = self.block_id(req.to_block)?;
+		let block_heights = from_block..=to_block;
+
+		let count = req.count.unwrap_or(self.max_count);
+		if count > self.max_count {
+			return Err(internal_err(format!(
+				"count ({}) can't be greater than maximum ({})",
+				count, self.max_count
+			)));
+		}
+
+		// Build a list of all the Substrate block hashes that need to be traced.
+		let mut block_hashes = vec![];
+		for block_height in block_heights {
+			if block_height == 0 {
+				continue; // no traces for genesis block.
+			}
+
+			let block_id = BlockId::<B>::Number(block_height);
+			let block_header = self
+				.client
+				.header(block_id)
+				.map_err(|e| {
+					internal_err(format!(
+						"Error when fetching block {} header : {:?}",
+						block_height, e
+					))
+				})?
+				.ok_or_else(|| {
+					internal_err(format!("Block with height {} don't exist", block_height))
+				})?;
+
+			let block_hash = block_header.hash();
+
+			block_hashes.push(block_hash);
+		}
+
+		// Start a batch with these blocks.
+		let batch_id = self.requester.start_batch(block_hashes.clone()).await?;
+		// Fetch all the traces. It is done in another function to simplify error handling and allow
+		// to call the following `stop_batch` regardless of the result. This is important for the
+		// cache cleanup to work properly.
+		let res = self.fetch_traces(req, &block_hashes, count as usize).await;
+		// Stop the batch, allowing the cache task to remove useless non-started block traces and
+		// start the expiration delay.
+		self.requester.stop_batch(batch_id).await;
+
+		res
+	}
+
+	async fn fetch_traces(
+		&self,
+		req: FilterRequest,
+		block_hashes: &[H256],
+		count: usize,
+	) -> Result<Vec<TransactionTrace>> {
+		let from_address = req.from_address.unwrap_or_default();
+		let to_address = req.to_address.unwrap_or_default();
+
+		let mut traces_amount: i64 = -(req.after.unwrap_or(0) as i64);
+		let mut traces = vec![];
+
+		for &block_hash in block_hashes {
+			// Request the traces of this block to the cache service.
+			// This will resolve quickly if the block is already cached, or wait until the block
+			// has finished tracing.
+			let block_traces = self.requester.get_traces(block_hash).await?;
+
+			// Filter addresses.
+			let mut block_traces: Vec<_> = block_traces
+				.iter()
+				.filter(|trace| match trace.action {
+					block::TransactionTraceAction::Call { from, to, .. } => {
+						(from_address.is_empty() || from_address.contains(&from))
+							&& (to_address.is_empty() || to_address.contains(&to))
+					}
+					block::TransactionTraceAction::Create { from, .. } => {
+						(from_address.is_empty() || from_address.contains(&from))
+							&& to_address.is_empty()
+					}
+					block::TransactionTraceAction::Suicide { address, .. } => {
+						(from_address.is_empty() || from_address.contains(&address))
+							&& to_address.is_empty()
+					}
+				})
+				.cloned()
+				.collect();
+
+			// Don't insert anything if we're still before "after"
+			traces_amount += block_traces.len() as i64;
+			if traces_amount > 0 {
+				let traces_amount = traces_amount as usize;
+				// If the current Vec of traces is across the "after" marker,
+				// we skip some elements of it.
+				if traces_amount < block_traces.len() {
+					let skip = block_traces.len() - traces_amount;
+					block_traces = block_traces.into_iter().skip(skip).collect();
+				}
+
+				traces.append(&mut block_traces);
+
+				// If we go over "count" (the limit), we trim and exit the loop,
+				// unless we used the default maximum, in which case we return an error.
+				if traces_amount >= count {
+					if req.count.is_none() {
+						return Err(internal_err(format!(
+							"the amount of traces goes over the maximum ({}), please use 'after' \
+							and 'count' in your request",
+							self.max_count
+						)));
+					}
+
+					traces = traces.into_iter().take(count).collect();
+					break;
+				}
+			}
+		}
+
+		Ok(traces)
+	}
+}
+
+impl<B, C> TraceT for Trace<B, C>
+where
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	B::Header: HeaderT<Number = u32>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+{
+	fn filter(
+		&self,
+		filter: FilterRequest,
+	) -> BoxFuture<'static, jsonrpc_core::Result<Vec<TransactionTrace>>> {
+		self.clone().filter(filter).boxed()
+	}
+}
+
+/// An opaque batch ID.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CacheBatchId(u64);
+
+/// Requests the cache task can accept.
+enum CacheRequest {
+	/// Request to start caching the provided range of blocks.
+	/// The task will add to blocks to its pool and immediately return a new batch ID.
+	StartBatch {
+		/// Returns the ID of the batch for cancellation.
+		sender: oneshot::Sender<CacheBatchId>,
+		/// List of block hash to trace.
+		blocks: Vec<H256>,
+	},
+	/// Fetch the traces for given block hash.
+	/// The task will answer only when it has processed this block.
+	GetTraces {
+		/// Returns the array of traces or an error.
+		sender: oneshot::Sender<Result<Vec<TransactionTrace>>>,
+		/// Hash of the block.
+		block: H256,
+	},
+	/// Notify the cache that it can stop the batch with that ID. Any block contained only in
+	/// this batch and still not started will be discarded.
+	StopBatch { batch_id: CacheBatchId },
+}
+
+/// Allows to interact with the cache task.
+#[derive(Clone)]
+pub struct CacheRequester(TracingUnboundedSender<CacheRequest>);
+
+impl CacheRequester {
+	/// Request to start caching the provided range of blocks.
+	/// The task will add to blocks to its pool and immediately return the batch ID.
+	#[instrument(skip(self))]
+	pub async fn start_batch(&self, blocks: Vec<H256>) -> Result<CacheBatchId> {
+		let (response_tx, response_rx) = oneshot::channel();
+		let mut sender = self.0.clone();
+
+		sender
+			.send(CacheRequest::StartBatch {
+				sender: response_tx,
+				blocks,
+			})
+			.await
+			.map_err(|e| {
+				internal_err(format!(
+					"Failed to send request to the trace cache task. Error : {:?}",
+					e
+				))
+			})?;
+
+		response_rx.await.map_err(|e| {
+			internal_err(format!(
+				"Trace cache task closed the response channel. Error : {:?}",
+				e
+			))
+		})
+	}
+
+	/// Fetch the traces for given block hash.
+	/// The task will answer only when it has processed this block.
+	/// The block should be part of a batch first. If no batch has requested the block it will
+	/// return an error.
+	#[instrument(skip(self))]
+	pub async fn get_traces(&self, block: H256) -> Result<Vec<TransactionTrace>> {
+		let (response_tx, response_rx) = oneshot::channel();
+		let mut sender = self.0.clone();
+
+		sender
+			.send(CacheRequest::GetTraces {
+				sender: response_tx,
+				block,
+			})
+			.await
+			.map_err(|e| {
+				internal_err(format!(
+					"Failed to send request to the trace cache task. Error : {:?}",
+					e
+				))
+			})?;
+
+		response_rx
+			.await
+			.map_err(|e| {
+				internal_err(format!(
+					"Trace cache task closed the response channel. Error : {:?}",
+					e
+				))
+			})?
+			.map_err(|e| internal_err(format!("Failed to replay block. Error : {:?}", e)))
+	}
+
+	/// Notify the cache that it can stop the batch with that ID. Any block contained only in
+	/// this batch and still in the waiting pool will be discarded.
+	#[instrument(skip(self))]
+	pub async fn stop_batch(&self, batch_id: CacheBatchId) {
+		let mut sender = self.0.clone();
+
+		// Here we don't care if the request has been accepted or refused, the caller can't
+		// do anything with it.
+		let _ = sender
+			.send(CacheRequest::StopBatch { batch_id })
+			.await
+			.map_err(|e| {
+				internal_err(format!(
+					"Failed to send request to the trace cache task. Error : {:?}",
+					e
+				))
+			});
+	}
+}
+
+/// Data stored for each block in the cache.
+/// `active_batch_count` represents the number of batches using this
+/// block. It will increase immediatly when a batch is created, but will be
+/// decrease only after the batch ends and its expiration delay passes.
+/// It allows to keep the data in the cache for following requests that would use
+/// this block, which is important to handle pagination efficiently.
+struct CacheBlock {
+	active_batch_count: usize,
+	state: CacheBlockState,
+}
+
+/// State of a cached block. It can either be polled to be traced or cached.
+enum CacheBlockState {
+	/// Block has been added to the pool blocks to be replayed.
+	/// It may be currently waiting to be replayed or being replayed.
+	Pooled {
+		started: bool,
+		/// Multiple requests might query the same block while it is pooled to be
+		/// traced. They response channel is stored here, and the result will be
+		/// sent in all of them when the tracing is finished.
+		waiting_requests: Vec<oneshot::Sender<Result<Vec<TransactionTrace>>>>,
+		/// Channel used to unqueue a tracing that has not yet started.
+		/// A tracing will be unqueued if it has not yet been started and the last batch
+		/// needing this block is ended (ignoring the expiration delay).
+		/// It is not used directly, but dropping will wake up the receiver.
+		#[allow(dead_code)]
+		unqueue_sender: oneshot::Sender<()>,
+	},
+	/// Tracing has completed and the result is available. No Runtime API call
+	/// will be needed until this block cache is removed.
+	Cached {
+		traces: Result<Vec<TransactionTrace>>,
+	},
+}
+
+/// Tracing a block is done in a separate tokio blocking task to avoid clogging the async threads.
+/// For this reason a channel using this type is used by the blocking task to communicate with the
+/// main cache task.
+enum BlockingTaskMessage {
+	/// Notify the tracing for this block has started as the blocking task got a permit from
+	/// the semaphore. This is used to prevent the deletion of a cache entry for a block that has
+	/// started being traced.
+	Started { block_hash: H256 },
+	/// The tracing is finished and the result is send to the main task.
+	Finished {
+		block_hash: H256,
+		result: Result<Vec<TransactionTrace>>,
+	},
+}
+
+/// Type wrapper for the cache task, generic over the Client, Block and Backend types.
+pub struct CacheTask<B, C, BE> {
+	client: Arc<C>,
+	backend: Arc<BE>,
+	blocking_permits: Arc<Semaphore>,
+	cached_blocks: BTreeMap<H256, CacheBlock>,
+	batches: BTreeMap<u64, Vec<H256>>,
+	next_batch_id: u64,
+	_phantom: PhantomData<B>,
+}
+
+impl<B, C, BE> CacheTask<B, C, BE>
+where
+	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	C: ProvideRuntimeApi<B>,
+	C: StorageProvider<B, BE>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	B::Header: HeaderT<Number = u32>,
+	C::Api: BlockBuilder<B>,
+	C::Api: DebugRuntimeApi<B>,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	C::Api: ApiExt<B>,
+{
+	/// Create a new cache task.
+	///
+	/// Returns a Future that needs to be added to a tokio executor, and an handle allowing to
+	/// send requests to the task.
+	pub fn create(
+		client: Arc<C>,
+		backend: Arc<BE>,
+		cache_duration: Duration,
+		blocking_permits: Arc<Semaphore>,
+		overrides: Arc<OverrideHandle<B>>,
+	) -> (impl Future<Output = ()>, CacheRequester) {
+		// Communication with the outside world :
+		let (requester_tx, mut requester_rx) =
+			sc_utils::mpsc::tracing_unbounded("trace-filter-cache");
+
+		// Task running in the service.
+		let task = async move {
+			// The following variables are polled by the select! macro, and thus cannot be
+			// part of Self without introducing borrowing issues.
+			let mut batch_expirations = FuturesUnordered::new();
+			let (blocking_tx, mut blocking_rx) =
+				mpsc::channel(blocking_permits.available_permits() * 2);
+
+			// Contains the inner state of the cache task, excluding the pooled futures/channels.
+			// Having this object allow to refactor each event into its own function, simplifying
+			// the main loop.
+			let mut inner = Self {
+				client,
+				backend,
+				blocking_permits,
+				cached_blocks: BTreeMap::new(),
+				batches: BTreeMap::new(),
+				next_batch_id: 0,
+				_phantom: Default::default(),
+			};
+
+			// Main event loop. This loop must not contain any direct .await, as we want to
+			// react to events as fast as possible.
+			loop {
+				select! {
+					request = requester_rx.next() => {
+						match request {
+							None => break,
+							Some(CacheRequest::StartBatch {sender, blocks})
+								=> inner.request_start_batch(&blocking_tx, sender, blocks, overrides.clone()),
+							Some(CacheRequest::GetTraces {sender, block})
+								=> inner.request_get_traces(sender, block),
+							Some(CacheRequest::StopBatch {batch_id}) => {
+								// Cannot be refactored inside `request_stop_batch` because
+								// it has an unnamable type :C
+								batch_expirations.push(async move {
+									sleep(cache_duration).await;
+									batch_id
+								});
+
+								inner.request_stop_batch(batch_id);
+							},
+						}
+					},
+					message = blocking_rx.recv().fuse() => {
+						match message {
+							None => (),
+							Some(BlockingTaskMessage::Started { block_hash })
+								=> inner.blocking_started(block_hash),
+							Some(BlockingTaskMessage::Finished { block_hash, result })
+								=> inner.blocking_finished(block_hash, result),
+						}
+					},
+					batch_id = batch_expirations.next() => {
+						match batch_id {
+							None => (),
+							Some(batch_id) => inner.expired_batch(batch_id),
+						}
+					}
+				}
+			}
+		}
+		.instrument(tracing::debug_span!("trace_filter_cache"));
+
+		(task, CacheRequester(requester_tx))
+	}
+
+	/// Handle the creation of a batch.
+	/// Will start the tracing process for blocks that are not already in the cache.
+	#[instrument(skip(self, blocking_tx, sender, blocks, overrides))]
+	fn request_start_batch(
+		&mut self,
+		blocking_tx: &mpsc::Sender<BlockingTaskMessage>,
+		sender: oneshot::Sender<CacheBatchId>,
+		blocks: Vec<H256>,
+		overrides: Arc<OverrideHandle<B>>,
+	) {
+		tracing::trace!("Starting batch {}", self.next_batch_id);
+		self.batches.insert(self.next_batch_id, blocks.clone());
+
+		for block in blocks {
+			// The block is already in the cache, awesome !
+			if let Some(block_cache) = self.cached_blocks.get_mut(&block) {
+				block_cache.active_batch_count += 1;
+				tracing::trace!(
+					"Cache hit for block {}, now used by {} batches.",
+					block,
+					block_cache.active_batch_count
+				);
+			}
+			// Otherwise we need to queue this block for tracing.
+			else {
+				tracing::trace!("Cache miss for block {}, pooling it for tracing.", block);
+
+				let blocking_permits = Arc::clone(&self.blocking_permits);
+				let (unqueue_sender, unqueue_receiver) = oneshot::channel();
+				let client = Arc::clone(&self.client);
+				let backend = Arc::clone(&self.backend);
+				let blocking_tx = blocking_tx.clone();
+				let overrides = overrides.clone();
+
+				// Spawn all block caching asynchronously.
+				// It will wait to obtain a permit, then spawn a blocking task.
+				// When the blocking task returns its result, it is send
+				// thought a channel to the main task loop.
+				tokio::spawn(
+					async move {
+						tracing::trace!("Waiting for blocking permit or task cancellation");
+						let _permit = select!(
+							_ = unqueue_receiver.fuse() => {
+							tracing::trace!("Tracing of the block has been cancelled.");
+								return;
+							},
+							permit = blocking_permits.acquire().fuse() => permit,
+						);
+
+						// Warn the main task that block tracing as started, and
+						// this block cache entry should not be removed.
+						let _ = blocking_tx
+							.send(BlockingTaskMessage::Started { block_hash: block })
+							.await;
+
+						tracing::trace!("Start block tracing in a blocking task.");
+
+						// Perform block tracing in a tokio blocking task.
+						let result = async {
+							tokio::task::spawn_blocking(move || {
+								Self::cache_block(client, backend, block, overrides.clone())
+							})
+							.await
+							.map_err(|e| {
+								internal_err(format!(
+									"Tracing Substrate block {} panicked : {:?}",
+									block, e
+								))
+							})?
+						}
+						.await;
+
+						tracing::trace!("Block tracing finished, sending result to main task.");
+
+						// Send response to main task.
+						let _ = blocking_tx
+							.send(BlockingTaskMessage::Finished {
+								block_hash: block,
+								result,
+							})
+							.await;
+					}
+					.instrument(tracing::trace_span!("Block tracing", block = %block)),
+				);
+
+				// Insert the block in the cache.
+				self.cached_blocks.insert(
+					block,
+					CacheBlock {
+						active_batch_count: 1,
+						state: CacheBlockState::Pooled {
+							started: false,
+							waiting_requests: vec![],
+							unqueue_sender,
+						},
+					},
+				);
+			}
+		}
+
+		// Respond with the batch ID.
+		let _ = sender.send(CacheBatchId(self.next_batch_id));
+
+		// Increase batch ID for next request.
+		self.next_batch_id = self.next_batch_id.overflowing_add(1).0;
+	}
+
+	/// Handle a request to get the traces of the provided block.
+	/// - If the result is stored in the cache, it sends it immediatly.
+	/// - If the block is currently being pooled, it is added in this block cache waiting list,
+	///   and all requests concerning this block will be satisfied when the tracing for this block
+	///   is finished.
+	/// - If this block is missing from the cache, it means no batch asked for it. All requested
+	///   blocks should be contained in a batch beforehand, and thus an error is returned.
+	#[instrument(skip(self))]
+	fn request_get_traces(
+		&mut self,
+		sender: oneshot::Sender<Result<Vec<TransactionTrace>>>,
+		block: H256,
+	) {
+		if let Some(block_cache) = self.cached_blocks.get_mut(&block) {
+			match &mut block_cache.state {
+				CacheBlockState::Pooled {
+					ref mut waiting_requests,
+					..
+				} => {
+					tracing::warn!(
+						"A request asked a pooled block ({}), adding it to the list of \
+						waiting requests.",
+						block
+					);
+					waiting_requests.push(sender);
+				}
+				CacheBlockState::Cached { ref traces, .. } => {
+					tracing::warn!(
+						"A request asked a cached block ({}), sending the traces directly.",
+						block
+					);
+					let _ = sender.send(traces.clone());
+				}
+			}
+		} else {
+			tracing::warn!(
+				"An RPC request asked to get a block ({}) which was not batched.",
+				block
+			);
+			let _ = sender.send(Err(internal_err(format!(
+				"RPC request asked a block ({}) that was not batched",
+				block
+			))));
+		}
+	}
+
+	/// Handle a request to stop a batch.
+	/// For all blocks that needed to be traced, are only in this batch and not yet started, their
+	/// tracing is cancelled to save CPU-time and avoid attacks requesting large amount of blocks.
+	/// This batch data is not yet removed however. Instead a expiration delay timer is started
+	/// after which the data will indeed be cleared. (the code for that is in the main loop code
+	/// as it involved an unnamable type :C)
+	#[instrument(skip(self))]
+	fn request_stop_batch(&mut self, batch_id: CacheBatchId) {
+		tracing::trace!("Stopping batch {}", batch_id.0);
+		if let Some(blocks) = self.batches.get(&batch_id.0) {
+			for block in blocks {
+				let mut remove = false;
+
+				// We remove early the block cache if this batch is the last
+				// pooling this block.
+				if let Some(block_cache) = self.cached_blocks.get_mut(block) {
+					if block_cache.active_batch_count == 1
+						&& matches!(
+							block_cache.state,
+							CacheBlockState::Pooled { started: false, .. }
+						) {
+						remove = true;
+					}
+				}
+
+				if remove {
+					tracing::trace!("Pooled block {} is no longer requested.", block);
+					// Remove block from the cache. Drops the value,
+					// closing all the channels contained in it.
+					let _ = self.cached_blocks.remove(&block);
+				}
+			}
+		}
+	}
+
+	/// A tracing blocking task notifies it got a permit and is starting the tracing.
+	/// This started status is stored to avoid removing this block entry.
+	#[instrument(skip(self))]
+	fn blocking_started(&mut self, block_hash: H256) {
+		if let Some(block_cache) = self.cached_blocks.get_mut(&block_hash) {
+			if let CacheBlockState::Pooled {
+				ref mut started, ..
+			} = block_cache.state
+			{
+				*started = true;
+			}
+		}
+	}
+
+	/// A tracing blocking task notifies it has finished the tracing and provide the result.
+	#[instrument(skip(self, result))]
+	fn blocking_finished(&mut self, block_hash: H256, result: Result<Vec<TransactionTrace>>) {
+		// In some cases it might be possible to receive traces of a block
+		// that has no entry in the cache because it was removed of the pool
+		// and received a permit concurrently. We just ignore it.
+		//
+		// TODO : Should we add it back ? Should it have an active_batch_count
+		// of 1 then ?
+		if let Some(block_cache) = self.cached_blocks.get_mut(&block_hash) {
+			if let CacheBlockState::Pooled {
+				ref mut waiting_requests,
+				..
+			} = block_cache.state
+			{
+				tracing::trace!(
+					"A new block ({}) has been traced, adding it to the cache and responding to \
+					{} waiting requests.",
+					block_hash,
+					waiting_requests.len()
+				);
+				// Send result in waiting channels
+				while let Some(channel) = waiting_requests.pop() {
+					let _ = channel.send(result.clone());
+				}
+
+				// Update cache entry
+				block_cache.state = CacheBlockState::Cached { traces: result };
+			}
+		}
+	}
+
+	/// A batch expiration delay timer has completed. It performs the cache cleaning for blocks
+	/// not longer used by other batches.
+	#[instrument(skip(self))]
+	fn expired_batch(&mut self, batch_id: CacheBatchId) {
+		if let Some(batch) = self.batches.remove(&batch_id.0) {
+			for block in batch {
+				// For each block of the batch, we remove it if it was the
+				// last batch containing it.
+				let mut remove = false;
+				if let Some(block_cache) = self.cached_blocks.get_mut(&block) {
+					block_cache.active_batch_count -= 1;
+
+					if block_cache.active_batch_count == 0 {
+						remove = true;
+					}
+				}
+
+				if remove {
+					let _ = self.cached_blocks.remove(&block);
+				}
+			}
+		}
+	}
+
+	/// (In blocking task) Use the Runtime API to trace the block.
+	#[instrument(skip(client, backend, overrides))]
+	fn cache_block(
+		client: Arc<C>,
+		backend: Arc<BE>,
+		substrate_hash: H256,
+		overrides: Arc<OverrideHandle<B>>,
+	) -> Result<Vec<TransactionTrace>> {
+		let substrate_block_id = BlockId::Hash(substrate_hash);
+
+		// Get Subtrate block data.
+		let api = client.runtime_api();
+		let block_header = client
+			.header(substrate_block_id)
+			.map_err(|e| {
+				internal_err(format!(
+					"Error when fetching substrate block {} header : {:?}",
+					substrate_hash, e
+				))
+			})?
+			.ok_or_else(|| {
+				internal_err(format!("Subtrate block {} don't exist", substrate_block_id))
+			})?;
+
+		let height = *block_header.number();
+		let substrate_parent_id = BlockId::<B>::Hash(*block_header.parent_hash());
+
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_block_id,
+		);
+
+		// Get Ethereum block data.
+		let (eth_block, eth_transactions) = match overrides.schemas.get(&schema) {
+			Some(schema) => match (
+				schema.current_block(&substrate_block_id),
+				schema.current_transaction_statuses(&substrate_block_id),
+			) {
+				(Some(a), Some(b)) => (a, b),
+				_ => {
+					return Err(internal_err(format!(
+						"Failed to get Ethereum block data for Substrate block {}",
+						substrate_block_id
+					)))
+				}
+			},
+			_ => {
+				return Err(internal_err(format!(
+					"No storage override at {:?}",
+					substrate_block_id
+				)))
+			}
+		};
+
+		let eth_block_hash = eth_block.header.hash();
+		let eth_tx_hashes = eth_transactions
+			.iter()
+			.map(|t| t.transaction_hash)
+			.collect();
+
+		// Get extrinsics (containing Ethereum ones)
+		let extrinsics = backend
+			.blockchain()
+			.body(substrate_block_id)
+			.map_err(|e| {
+				internal_err(format!(
+					"Blockchain error when fetching extrinsics of block {} : {:?}",
+					height, e
+				))
+			})?
+			.ok_or_else(|| {
+				internal_err(format!(
+					"Could not find block {} when fetching extrinsics.",
+					height
+				))
+			})?;
+
+		// Trace the block.
+		let f = || -> Result<_> {
+			api.initialize_block(&substrate_parent_id, &block_header)
+				.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+
+			let _result = api
+				.trace_block(&substrate_parent_id, extrinsics, eth_tx_hashes)
+				.map_err(|e| {
+					internal_err(format!(
+						"Blockchain error when replaying block {} : {:?}",
+						height, e
+					))
+				})?
+				.map_err(|e| {
+					tracing::warn!(
+						"Internal runtime error when replaying block {} : {:?}",
+						height,
+						e
+					);
+					internal_err(format!(
+						"Internal runtime error when replaying block {} : {:?}",
+						height, e
+					))
+				})?;
+			Ok(peaq_rpc_primitives_debug::Response::Block)
+		};
+
+		let mut proxy = peaq_client_evm_tracing::listeners::CallList::default();
+		proxy.using(f)?;
+		let mut traces: Vec<_> =
+			peaq_client_evm_tracing::formatters::TraceFilter::format(proxy).unwrap();
+		// Fill missing data.
+		for trace in traces.iter_mut() {
+			trace.block_hash = eth_block_hash;
+			trace.block_number = height;
+			trace.transaction_hash = eth_transactions
+				.get(trace.transaction_position as usize)
+				.ok_or_else(|| {
+					tracing::warn!(
+						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+						height
+					);
+
+					internal_err(format!(
+						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+						height
+					))
+				})?
+				.transaction_hash;
+
+			// Reformat error messages.
+			if let block::TransactionTraceOutput::Error(ref mut error) = trace.output {
+				if error.as_slice() == b"execution reverted" {
+					*error = b"Reverted".to_vec();
+				}
+			}
+		}
+		Ok(traces)
+	}
+}

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-txpool"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "peaq-rpc-txpool"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+# [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.6.0"
+
+[dependencies]
+jsonrpc-core = "18.0.0"
+rlp = "0.5"
+serde = { version = "1.0", features = [ "derive" ] }
+sha3 = "0.9"
+
+peaq-rpc-core-txpool = { path = "../../rpc-core/txpool" }
+peaq-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
+
+# Substrate
+frame-system = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sc-transaction-pool = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sc-transaction-pool-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-blockchain = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-io = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16" }
+
+# Frontier
+ethereum-types = "0.12.1"
+fc-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16", features = [ "rpc_binary_search_estimate" ] }

--- a/client/rpc/txpool/src/lib.rs
+++ b/client/rpc/txpool/src/lib.rs
@@ -1,0 +1,184 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethereum_types::{H160, H256, U256};
+use fc_rpc::{internal_err, public_key};
+use jsonrpc_core::Result as RpcResult;
+pub use peaq_rpc_core_txpool::{
+	GetT, Summary, Transaction, TransactionMap, TxPool as TxPoolT, TxPoolResult, TxPoolServer,
+};
+use sc_transaction_pool::{ChainApi, Pool};
+use sc_transaction_pool_api::InPoolTransaction;
+use serde::Serialize;
+use sha3::{Digest, Keccak256};
+use sp_api::{ApiExt, BlockId, ProvideRuntimeApi};
+use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_runtime::traits::Block as BlockT;
+use std::collections::HashMap;
+use std::{marker::PhantomData, sync::Arc};
+
+use peaq_rpc_primitives_txpool::{
+	Transaction as TransactionV2, TxPoolResponse, TxPoolRuntimeApi,
+};
+
+pub struct TxPool<B: BlockT, C, A: ChainApi> {
+	client: Arc<C>,
+	graph: Arc<Pool<A>>,
+	_marker: PhantomData<B>,
+}
+
+impl<B, C, A> TxPool<B, C, A>
+where
+	C: ProvideRuntimeApi<B>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B> + 'static,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
+	C::Api: TxPoolRuntimeApi<B>,
+{
+	/// Use the transaction graph interface to get the extrinsics currently in the ready and future
+	/// queues.
+	fn map_build<T>(&self) -> RpcResult<TxPoolResult<TransactionMap<T>>>
+	where
+		T: GetT + Serialize,
+	{
+		// Collect transactions in the ready validated pool.
+		let txs_ready = self
+			.graph
+			.validated_pool()
+			.ready()
+			.map(|in_pool_tx| in_pool_tx.data().clone())
+			.collect();
+
+		// Collect transactions in the future validated pool.
+		let txs_future = self
+			.graph
+			.validated_pool()
+			.futures()
+			.iter()
+			.map(|(_hash, extrinsic)| extrinsic.clone())
+			.collect();
+
+		// Use the runtime to match the (here) opaque extrinsics against ethereum transactions.
+		let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
+		let api = self.client.runtime_api();
+		let api_version = if let Ok(Some(api_version)) =
+			api.api_version::<dyn TxPoolRuntimeApi<B>>(&best_block)
+		{
+			api_version
+		} else {
+			return Err(internal_err(format!(
+				"failed to retrieve Runtime Api version"
+			)));
+		};
+		let ethereum_txns: TxPoolResponse = if api_version == 1 {
+			#[allow(deprecated)]
+			let res = api.extrinsic_filter_before_version_2(&best_block, txs_ready, txs_future)
+				.map_err(|err| {
+					internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
+				})?;
+			TxPoolResponse {
+				ready: res
+					.ready
+					.iter()
+					.map(|t| TransactionV2::Legacy(t.clone()))
+					.collect(),
+				future: res
+					.future
+					.iter()
+					.map(|t| TransactionV2::Legacy(t.clone()))
+					.collect(),
+			}
+		} else {
+			api.extrinsic_filter(&best_block, txs_ready, txs_future)
+				.map_err(|err| {
+					internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
+				})?
+		};
+		// Build the T response.
+		let mut pending = TransactionMap::<T>::new();
+		for txn in ethereum_txns.ready.iter() {
+			let hash = txn.hash();
+			let nonce = match txn {
+				TransactionV2::Legacy(t) => t.nonce,
+				TransactionV2::EIP2930(t) => t.nonce,
+				TransactionV2::EIP1559(t) => t.nonce,
+			};
+			let from_address = match public_key(txn) {
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Err(_e) => H160::default(),
+			};
+			pending
+				.entry(from_address)
+				.or_insert_with(HashMap::new)
+				.insert(nonce, T::get(hash, from_address, txn));
+		}
+		let mut queued = TransactionMap::<T>::new();
+		for txn in ethereum_txns.future.iter() {
+			let hash = txn.hash();
+			let nonce = match txn {
+				TransactionV2::Legacy(t) => t.nonce,
+				TransactionV2::EIP2930(t) => t.nonce,
+				TransactionV2::EIP1559(t) => t.nonce,
+			};
+			let from_address = match public_key(txn) {
+				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
+				Err(_e) => H160::default(),
+			};
+			queued
+				.entry(from_address)
+				.or_insert_with(HashMap::new)
+				.insert(nonce, T::get(hash, from_address, txn));
+		}
+		Ok(TxPoolResult { pending, queued })
+	}
+}
+
+impl<B: BlockT, C, A: ChainApi> TxPool<B, C, A> {
+	pub fn new(client: Arc<C>, graph: Arc<Pool<A>>) -> Self {
+		Self {
+			client,
+			graph,
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<B, C, A> TxPoolT for TxPool<B, C, A>
+where
+	C: ProvideRuntimeApi<B>,
+	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
+	C: Send + Sync + 'static,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
+	C::Api: TxPoolRuntimeApi<B>,
+{
+	fn content(&self) -> RpcResult<TxPoolResult<TransactionMap<Transaction>>> {
+		self.map_build::<Transaction>()
+	}
+
+	fn inspect(&self) -> RpcResult<TxPoolResult<TransactionMap<Summary>>> {
+		self.map_build::<Summary>()
+	}
+
+	fn status(&self) -> RpcResult<TxPoolResult<U256>> {
+		let status = self.graph.validated_pool().status();
+		Ok(TxPoolResult {
+			pending: U256::from(status.ready),
+			queued: U256::from(status.future),
+		})
+	}
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -253,6 +253,32 @@ git = 'https://github.com/peaqnetwork/substrate'
 branch = "peaq-polkadot-v0.9.16"
 
 
+# Tracing
+[dependencies.peaq-rpc-debug]
+path = '../client/rpc/debug'
+
+[dependencies.peaq-rpc-primitives-debug]
+path = '../primitives/rpc/debug'
+
+[dependencies.peaq-rpc-primitives-txpool]
+path = '../primitives/rpc/txpool'
+
+[dependencies.peaq-rpc-trace]
+path = '../client/rpc/trace'
+
+[dependencies.peaq-rpc-txpool]
+path = '../client/rpc/txpool'
+
+[dependencies.tokio]
+version = "1.13.0"
+features = [ "macros", "sync" ]
+
+# peaq-rpc-debug = { path = "../../client/rpc/debug" }
+# peaq-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
+# peaq-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool" }
+# peaq-rpc-trace = { path = "../../client/rpc/trace" }
+# peaq-rpc-txpool = { path = "../../client/rpc/txpool" }
+
 [features]
 default = ['aura']
 aura = ["peaq-node-runtime/aura"]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -254,6 +254,9 @@ branch = "peaq-polkadot-v0.9.16"
 
 
 # Tracing
+[dependencies.peaq-primitives-ext]
+path = '../primitives/ext'
+
 [dependencies.peaq-rpc-debug]
 path = '../client/rpc/debug'
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -37,7 +37,6 @@ pub struct RunCmd {
 	/// Enable EVM tracing module on a non-authority node.
 	#[structopt(
 		long,
-		// [TODO]????
 		conflicts_with = "validator",
 		require_delimiter = true
 	)]
@@ -61,7 +60,6 @@ pub struct RunCmd {
 	/// Size of the LRU cache for block data and their transaction statuses.
 	#[structopt(long, default_value = "3000")]
 	pub eth_log_block_cache: usize,
-
 
 	#[structopt(long = "enable-dev-signer")]
 	pub enable_dev_signer: bool,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "manual-seal")]
 use structopt::clap::arg_enum;
 use structopt::StructOpt;
+use crate::cli_opt::EthApi;
 
 #[cfg(feature = "manual-seal")]
 arg_enum! {
@@ -32,6 +33,35 @@ pub struct RunCmd {
 	/// Choose sealing method.
 	#[structopt(long = "sealing")]
 	pub sealing: Sealing,
+
+	/// Enable EVM tracing module on a non-authority node.
+	#[structopt(
+		long,
+		// [TODO]????
+		conflicts_with = "validator",
+		require_delimiter = true
+	)]
+	pub ethapi: Vec<EthApi>,
+
+	/// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
+	#[structopt(long, default_value = "10")]
+	pub ethapi_max_permits: u32,
+
+	/// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
+	/// A request asking for more or an unbounded one going over this limit will both return an
+	/// error.
+	#[structopt(long, default_value = "500")]
+	pub ethapi_trace_max_count: u32,
+
+	/// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
+	/// discarded.
+	#[structopt(long, default_value = "300")]
+	pub ethapi_trace_cache_duration: u64,
+
+	/// Size of the LRU cache for block data and their transaction statuses.
+	#[structopt(long, default_value = "3000")]
+	pub eth_log_block_cache: usize,
+
 
 	#[structopt(long = "enable-dev-signer")]
 	pub enable_dev_signer: bool,

--- a/node/src/cli_opt.rs
+++ b/node/src/cli_opt.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum EthApi {
+	Txpool,
+	Debug,
+	Trace,
+}
+
+impl FromStr for EthApi {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			"txpool" => Self::Txpool,
+			"debug" => Self::Debug,
+			"trace" => Self::Trace,
+			_ => {
+				return Err(format!(
+					"`{}` is not recognized as a supported Ethereum Api",
+					s
+				))
+			}
+		})
+	}
+}
+
+pub struct RpcConfig {
+	pub ethapi: Vec<EthApi>,
+	pub ethapi_max_permits: u32,
+	pub ethapi_trace_max_count: u32,
+	pub ethapi_trace_cache_duration: u64,
+	pub eth_log_block_cache: usize,
+	pub max_past_logs: u32,
+	pub fee_history_limit: u64,
+}

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -68,7 +68,7 @@ fn validate_trace_environment(cli: &Cli) -> sc_cli::Result<()> {
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
-	let _ = validate_trace_environment(&cli)?;
+	// let _ = validate_trace_environment(&cli)?;
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -68,7 +68,7 @@ fn validate_trace_environment(cli: &Cli) -> sc_cli::Result<()> {
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
-	// let _ = validate_trace_environment(&cli)?;
+	let _ = validate_trace_environment(&cli)?;
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -5,6 +5,7 @@ mod chain_spec;
 #[macro_use]
 mod service;
 mod cli;
+mod cli_opt;
 mod command;
 mod rpc;
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -48,7 +48,6 @@ pub struct SpawnTasksParams<'a, B: BlockT, C, BE> {
 }
 
 /// Full client dependencies.
-//[TODO]
 //pub struct FullDeps<C, P, A: ChainApi, BE> {
 pub struct FullDeps<C, P, A: ChainApi> {
 	/// The client instance to use.
@@ -69,11 +68,6 @@ pub struct FullDeps<C, P, A: ChainApi> {
 	pub filter_pool: Option<FilterPool>,
 	/// Backend.
 	pub backend: Arc<fc_db::Backend<Block>>,
-	// // [TODO]
-	// /// Frontier Backend.
-	// pub frontier_backend: Arc<fc_db::Backend<Block>>,
-	// /// Backend.
-	// pub backend: Arc<BE>,
 	/// Maximum number of logs in a query.
 	pub max_past_logs: u32,
 	/// Maximum fee history cache size.
@@ -124,8 +118,6 @@ where
 /// Instantiate all full RPC extensions.
 pub fn create_full<C, P, BE, A>(
 	deps: FullDeps<C, P, A>,
-	// [TODO]
-	// deps: FullDeps<C, P, A, BE>,
 	subscription_task_executor: SubscriptionTaskExecutor,
 	overrides: Arc<OverrideHandle<Block>>,
 ) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
@@ -169,9 +161,6 @@ where
 		filter_pool,
 		command_sink,
 		backend,
-		// [TODO]
-		// backend: _,
-		// frontier_backend,
 		max_past_logs,
 		fee_history_limit,
 		fee_history_cache,
@@ -224,8 +213,6 @@ where
 		signers,
 		overrides.clone(),
 		backend.clone(),
-		// [TODO]
-		// frontier_backend.clone(),
 		is_authority,
 		max_past_logs,
 		block_data_cache.clone(),
@@ -238,8 +225,6 @@ where
 		io.extend_with(EthFilterApiServer::to_delegate(EthFilterApi::new(
 			client.clone(),
 			backend,
-			// [TODO]
-			// frontier_backend,
 			filter_pool.clone(),
 			500_usize, // max stored filters
 			overrides.clone(),

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -30,6 +30,21 @@ use sp_runtime::traits::BlakeTwo256;
 //For ink! contracts
 use pallet_contracts_rpc::{Contracts, ContractsApi};
 
+use sp_runtime::traits::Block as BlockT;
+use sc_service::TaskManager;
+pub mod tracing;
+
+pub struct SpawnTasksParams<'a, B: BlockT, C, BE> {
+	pub task_manager: &'a TaskManager,
+	pub client: Arc<C>,
+	pub substrate_backend: Arc<BE>,
+	pub frontier_backend: Arc<fc_db::Backend<B>>,
+	pub filter_pool: Option<FilterPool>,
+	pub overrides: Arc<OverrideHandle<B>>,
+	pub fee_history_limit: u64,
+	pub fee_history_cache: FeeHistoryCache,
+}
+
 /// Full client dependencies.
 pub struct FullDeps<C, P, A: ChainApi> {
 	/// The client instance to use.

--- a/node/src/rpc/tracing.rs
+++ b/node/src/rpc/tracing.rs
@@ -1,0 +1,139 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+use peaq_rpc_debug::DebugHandler;
+use peaq_rpc_debug::{Debug, DebugRequester, DebugServer};
+use peaq_rpc_trace::{
+	CacheRequester as TraceFilterCacheRequester, CacheTask, Trace, TraceServer,
+};
+use tokio::sync::Semaphore;
+
+use crate::cli_opt::EthApi as EthApiCmd;
+use fp_rpc::EthereumRuntimeRPCApi;
+// use crate::client::RuntimeApiCollection;
+use sp_core::H256;
+use sc_client_api::BlockOf;
+use sp_api::HeaderT;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct RpcRequesters {
+	pub debug: Option<DebugRequester>,
+	pub trace: Option<TraceFilterCacheRequester>,
+}
+
+pub fn extend_with_tracing<C, BE>(
+	client: Arc<C>,
+	requesters: RpcRequesters,
+	trace_filter_max_count: u32,
+	io: &mut jsonrpc_core::IoHandler<sc_rpc::Metadata>,
+) where
+	BE: Backend<Block> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	BE::Blockchain: BlockchainBackend<Block>,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
+	C: BlockchainEvents<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
+	C: Send + Sync + 'static,
+	// C::Api: RuntimeApiCollection<StateBackend = BE::State>,
+{
+	if let Some(trace_filter_requester) = requesters.trace {
+		io.extend_with(TraceServer::to_delegate(Trace::new(
+			client,
+			trace_filter_requester,
+			trace_filter_max_count,
+		)));
+	}
+
+	if let Some(debug_requester) = requesters.debug {
+		io.extend_with(DebugServer::to_delegate(Debug::new(debug_requester)));
+	}
+}
+
+// Spawn the tasks that are required to run a Moonbeam tracing node.
+pub fn spawn_tracing_tasks<B, C, BE>(
+	rpc_config: &crate::cli_opt::RpcConfig,
+	params: SpawnTasksParams<B, C, BE>,
+) -> RpcRequesters
+where
+	C: ProvideRuntimeApi<B> + BlockOf,
+	C: StorageProvider<B, BE>,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error = BlockChainError> + 'static,
+	C: BlockchainEvents<B>,
+	C: Send + Sync + 'static,
+	C::Api: EthereumRuntimeRPCApi<B> + peaq_rpc_primitives_debug::DebugRuntimeApi<B>,
+	C::Api: BlockBuilder<B>,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	B::Header: HeaderT<Number = u32>,
+	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+{
+	let permit_pool = Arc::new(Semaphore::new(rpc_config.ethapi_max_permits as usize));
+
+	let (trace_filter_task, trace_filter_requester) =
+		if rpc_config.ethapi.contains(&EthApiCmd::Trace) {
+			let (trace_filter_task, trace_filter_requester) = CacheTask::create(
+				Arc::clone(&params.client),
+				Arc::clone(&params.substrate_backend),
+				Duration::from_secs(rpc_config.ethapi_trace_cache_duration),
+				Arc::clone(&permit_pool),
+				Arc::clone(&params.overrides),
+			);
+			(Some(trace_filter_task), Some(trace_filter_requester))
+		} else {
+			(None, None)
+		};
+
+	let (debug_task, debug_requester) = if rpc_config.ethapi.contains(&EthApiCmd::Debug) {
+		let (debug_task, debug_requester) = DebugHandler::task(
+			Arc::clone(&params.client),
+			Arc::clone(&params.substrate_backend),
+			Arc::clone(&params.frontier_backend),
+			Arc::clone(&permit_pool),
+			Arc::clone(&params.overrides),
+		);
+		(Some(debug_task), Some(debug_requester))
+	} else {
+		(None, None)
+	};
+
+	// `trace_filter` cache task. Essential.
+	// Proxies rpc requests to it's handler.
+	if let Some(trace_filter_task) = trace_filter_task {
+		params.task_manager.spawn_essential_handle().spawn(
+			"trace-filter-cache",
+			Some("eth-tracing"),
+			trace_filter_task,
+		);
+	}
+
+	// `debug` task if enabled. Essential.
+	// Proxies rpc requests to it's handler.
+	if let Some(debug_task) = debug_task {
+		params.task_manager.spawn_essential_handle().spawn(
+			"ethapi-debug",
+			Some("eth-tracing"),
+			debug_task,
+		);
+	}
+
+	RpcRequesters {
+		debug: debug_requester,
+		trace: trace_filter_requester,
+	}
+}

--- a/node/src/rpc/tracing.rs
+++ b/node/src/rpc/tracing.rs
@@ -99,6 +99,16 @@ where
 			(None, None)
 		};
 
+	// `trace_filter` cache task. Essential.
+	// Proxies rpc requests to it's handler.
+	if let Some(trace_filter_task) = trace_filter_task {
+		params.task_manager.spawn_essential_handle().spawn(
+			"trace-filter-cache",
+			Some("eth-tracing"),
+			trace_filter_task,
+		);
+	}
+
 	let (debug_task, debug_requester) = if rpc_config.ethapi.contains(&EthApiCmd::Debug) {
 		let (debug_task, debug_requester) = DebugHandler::task(
 			Arc::clone(&params.client),
@@ -111,16 +121,6 @@ where
 	} else {
 		(None, None)
 	};
-
-	// `trace_filter` cache task. Essential.
-	// Proxies rpc requests to it's handler.
-	if let Some(trace_filter_task) = trace_filter_task {
-		params.task_manager.spawn_essential_handle().spawn(
-			"trace-filter-cache",
-			Some("eth-tracing"),
-			trace_filter_task,
-		);
-	}
 
 	// `debug` task if enabled. Essential.
 	// Proxies rpc requests to it's handler.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -34,12 +34,15 @@ use std::{
 };
 
 use crate::cli_opt::RpcConfig;
-
+pub type HostFunctions = (
+	frame_benchmarking::benchmarking::HostFunctions,
+	peaq_primitives_ext::peaq_ext::HostFunctions,
+);
 // Our native executor instance.
 pub struct ExecutorDispatch;
 
 impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
-	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+	type ExtendHostFunctions = HostFunctions;
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
 		peaq_node_runtime::api::dispatch(method, data)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -304,7 +304,6 @@ fn remote_keystore(_url: &String) -> Result<Arc<LocalKeystore>, &'static str> {
 
 /// Builds a new service for a full client.
 pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> Result<TaskManager, ServiceError> {
-    // [TODO] Ned to check
 	let sc_service::PartialComponents {
 		client,
 		backend,
@@ -392,7 +391,6 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 	let subscription_task_executor =
 		sc_rpc::SubscriptionTaskExecutor::new(task_manager.spawn_handle());
 
-    // [TODO] Ned to check
 	let overrides = crate::rpc::overrides_handle(client.clone());
 	let fee_history_limit = rpc_config.fee_history_limit;
 
@@ -425,8 +423,6 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 		let network = network.clone();
 		let ethapi_cmd = ethapi_cmd.clone();
 		let filter_pool = filter_pool.clone();
-		// [TODO]
-		// let backend = backend.clone();
 		let frontier_backend = frontier_backend.clone();
 		let overrides = overrides.clone();
 		let fee_history_cache = fee_history_cache.clone();
@@ -443,9 +439,6 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 				network: network.clone(),
 				filter_pool: filter_pool.clone(),
 				backend: frontier_backend.clone(),
-				// [TODO]
-				// backend: backend.clone(),
-				// frontier_backend: frontier_backend.clone(),
 				max_past_logs,
 				fee_history_limit,
 				fee_history_cache: fee_history_cache.clone(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -301,6 +301,7 @@ fn remote_keystore(_url: &String) -> Result<Arc<LocalKeystore>, &'static str> {
 
 /// Builds a new service for a full client.
 pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> Result<TaskManager, ServiceError> {
+    // [TODO] Ned to check
 	let sc_service::PartialComponents {
 		client,
 		backend,
@@ -387,10 +388,12 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 	let enable_dev_signer = cli.run.enable_dev_signer;
 	let subscription_task_executor =
 		sc_rpc::SubscriptionTaskExecutor::new(task_manager.spawn_handle());
+
+    // [TODO] Ned to check
 	let overrides = crate::rpc::overrides_handle(client.clone());
+	let fee_history_limit = rpc_config.fee_history_limit;
 
 	let ethapi_cmd = rpc_config.ethapi.clone();
-	let fee_history_limit = rpc_config.fee_history_limit;
 	let tracing_requesters =
 		if ethapi_cmd.contains(&EthApiCmd::Debug) || ethapi_cmd.contains(&EthApiCmd::Trace) {
 			crate::rpc::tracing::spawn_tracing_tasks(
@@ -419,6 +422,8 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 		let network = network.clone();
 		let ethapi_cmd = ethapi_cmd.clone();
 		let filter_pool = filter_pool.clone();
+		// [TODO]
+		// let backend = backend.clone();
 		let frontier_backend = frontier_backend.clone();
 		let overrides = overrides.clone();
 		let fee_history_cache = fee_history_cache.clone();
@@ -435,10 +440,15 @@ pub fn new_full(mut config: Configuration, cli: &Cli, rpc_config: RpcConfig) -> 
 				network: network.clone(),
 				filter_pool: filter_pool.clone(),
 				backend: frontier_backend.clone(),
+				// [TODO]
+				// backend: backend.clone(),
+				// frontier_backend: frontier_backend.clone(),
 				max_past_logs,
 				fee_history_limit,
 				fee_history_cache: fee_history_cache.clone(),
 				command_sink: Some(command_sink.clone()),
+				ethapi_cmd: ethapi_cmd.clone(),
+				eth_log_block_cache: rpc_config.eth_log_block_cache,
 			};
 
 			#[allow(unused_mut)]

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-primitives-ext"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "peaq-primitives-ext"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+// [TODO] Should we chang the License?
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+ethereum-types = { version = "0.12.1", default-features = false }
+
+evm-tracing-events = { path = "../rpc/evm-tracing-events", default-features = false }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-externalities = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-runtime-interface = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"ethereum-types/std",
+	"evm-tracing-events/std",
+	"sp-externalities/std",
+	"sp-runtime-interface/std",
+	"sp-std/std",
+]

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -3,7 +3,7 @@ name = "peaq-primitives-ext"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-// [TODO] Should we chang the License?
+# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -1,0 +1,82 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Environmental-aware externalities for EVM tracing in Wasm runtime. This enables
+//! capturing the - potentially large - trace output data in the host and keep
+//! a low memory footprint in `--execution=wasm`.
+//!
+//! - The original trace Runtime Api call is wrapped `using` environmental (thread local).
+//! - Arguments are scale-encoded known types in the host.
+//! - Host functions will decode the input and emit an event `with` environmental.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+use sp_runtime_interface::runtime_interface;
+
+use codec::Decode;
+use sp_std::vec::Vec;
+
+use evm_tracing_events::{Event, EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};
+
+#[runtime_interface]
+pub trait PeaqExt {
+	fn raw_step(&mut self, _data: Vec<u8>) {}
+
+	fn raw_gas(&mut self, _data: Vec<u8>) {}
+
+	fn raw_return_value(&mut self, _data: Vec<u8>) {}
+
+	fn call_list_entry(&mut self, _index: u32, _value: Vec<u8>) {}
+
+	fn call_list_new(&mut self) {}
+
+	// New design, proxy events.
+	/// An `Evm` event proxied by the Moonbeam runtime to this host function.
+	/// evm -> moonbeam_runtime -> host.
+	fn evm_event(&mut self, event: Vec<u8>) {
+		if let Ok(event) = EvmEvent::decode(&mut &event[..]) {
+			Event::Evm(event).emit();
+		}
+	}
+
+	/// A `Gasometer` event proxied by the Moonbeam runtime to this host function.
+	/// evm_gasometer -> moonbeam_runtime -> host.
+	fn gasometer_event(&mut self, event: Vec<u8>) {
+		if let Ok(event) = GasometerEvent::decode(&mut &event[..]) {
+			Event::Gasometer(event).emit();
+		}
+	}
+
+	/// A `Runtime` event proxied by the Moonbeam runtime to this host function.
+	/// evm_runtime -> moonbeam_runtime -> host.
+	fn runtime_event(&mut self, event: Vec<u8>) {
+		if let Ok(event) = RuntimeEvent::decode(&mut &event[..]) {
+			Event::Runtime(event).emit();
+		}
+	}
+
+	/// Allow the tracing module in the runtime to know how to filter Step event
+	/// content, as cloning the entire data is expensive and most of the time
+	/// not necessary.
+	fn step_event_filter(&self) -> StepEventFilter {
+		evm_tracing_events::step_event_filter().unwrap_or_default()
+	}
+
+	/// An event to create a new CallList (currently a new transaction when tracing a block).
+	#[version(2)]
+	fn call_list_new(&mut self) {
+		Event::CallListNew().emit();
+	}
+}

--- a/primitives/rpc/debug/Cargo.toml
+++ b/primitives/rpc/debug/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "peaq-rpc-primitives-debug"
+authors = [ "peaq network <https://github.com/peaqnetwork>" ]
+edition = "2021"
+homepage = "https://peaq.network/"
+# [TODO] We follow PureStak's code, should we change the license?
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+environmental = { version = "1.1.2", default-features = false }
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+ethereum-types = { version = "0.12.1", default-features = false }
+hex = { version = "0.4", optional = true, features = [ "serde" ] }
+serde = { version = "1.0", optional = true, features = [ "derive" ] }
+serde_json = { version = "1.0", optional = true }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-api = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-core = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-io = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-std = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"environmental/std",
+	"ethereum-types/std",
+	"ethereum/std",
+	"hex",
+	"serde",
+	"serde_json",
+	"sp-api/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/primitives/rpc/debug/Cargo.toml
+++ b/primitives/rpc/debug/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-primitives-debug"
 authors = [ "peaq network <https://github.com/peaqnetwork>" ]
 edition = "2021"
 homepage = "https://peaq.network/"
-# [TODO] We follow PureStak's code, should we change the license?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -1,0 +1,66 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
+use ethereum_types::H256;
+use sp_std::vec::Vec;
+
+sp_api::decl_runtime_apis! {
+	// Api version is virtually 4.
+	//
+	// We realized that even using runtime overrides, using the ApiExt interface reads the api
+	// versions from the state runtime, meaning we cannot just reset the versioning as we see fit.
+	//
+	// In order to be able to use ApiExt as part of the RPC handler logic we need to be always
+	// above the version that exists on chain for this Api, even if this Api is only meant
+	// to be used overriden.
+	#[api_version(4)]
+	pub trait DebugRuntimeApi {
+		#[changed_in(4)]
+		fn trace_transaction(
+			extrinsics: Vec<Block::Extrinsic>,
+			transaction: &LegacyTransaction,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		fn trace_transaction(
+			extrinsics: Vec<Block::Extrinsic>,
+			transaction: &Transaction,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		fn trace_block(
+			extrinsics: Vec<Block::Extrinsic>,
+			known_transactions: Vec<H256>,
+		) -> Result<(), sp_runtime::DispatchError>;
+	}
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode)]
+pub enum TracerInput {
+	None,
+	Blockscout,
+	CallTracer,
+}
+
+/// DebugRuntimeApi V2 result. Trace response is stored in client and runtime api call response is
+/// empty.
+#[derive(Debug)]
+pub enum Response {
+	Single,
+	Block,
+}

--- a/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "evm-tracing-events"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+// [TODO] Should we chang the License?
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+environmental = { version = "1.1.2", default-features = false }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-runtime-interface = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+# Ethereum
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+ethereum-types = { version = "0.12.1", default-features = false }
+evm = { version = "0.33.1", default-features = false, features = [ "with-codec" ] }
+evm-gasometer = { version = "0.33.0", default-features = false }
+evm-runtime = { version = "0.33.0", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"environmental/std",
+	"ethereum-types/std",
+	"ethereum/std",
+	"evm-gasometer/std",
+	"evm-runtime/std",
+	"evm/std",
+]
+evm-tracing = [ "evm-gasometer/tracing", "evm-runtime/tracing", "evm/tracing" ]

--- a/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -3,7 +3,7 @@ name = "evm-tracing-events"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-// [TODO] Should we chang the License?
+# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -3,7 +3,6 @@ name = "evm-tracing-events"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/primitives/rpc/evm-tracing-events/src/evm.rs
+++ b/primitives/rpc/evm-tracing-events/src/evm.rs
@@ -1,4 +1,3 @@
-// [TODO] Should I remove the Moonbeam's license??
 // Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 

--- a/primitives/rpc/evm-tracing-events/src/evm.rs
+++ b/primitives/rpc/evm-tracing-events/src/evm.rs
@@ -1,0 +1,231 @@
+// [TODO] Should I remove the Moonbeam's license??
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use ethereum_types::{H160, H256, U256};
+use evm::ExitReason;
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct Transfer {
+	/// Source address.
+	pub source: H160,
+	/// Target address.
+	pub target: H160,
+	/// Transfer value.
+	pub value: U256,
+}
+
+impl From<evm_runtime::Transfer> for Transfer {
+	fn from(i: evm_runtime::Transfer) -> Self {
+		Self {
+			source: i.source,
+			target: i.target,
+			value: i.value,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode)]
+pub enum CreateScheme {
+	/// Legacy create scheme of `CREATE`.
+	Legacy {
+		/// Caller of the create.
+		caller: H160,
+	},
+	/// Create scheme of `CREATE2`.
+	Create2 {
+		/// Caller of the create.
+		caller: H160,
+		/// Code hash.
+		code_hash: H256,
+		/// Salt.
+		salt: H256,
+	},
+	/// Create at a fixed location.
+	Fixed(H160),
+}
+
+impl From<evm_runtime::CreateScheme> for CreateScheme {
+	fn from(i: evm_runtime::CreateScheme) -> Self {
+		match i {
+			evm_runtime::CreateScheme::Legacy { caller } => Self::Legacy { caller },
+			evm_runtime::CreateScheme::Create2 {
+				caller,
+				code_hash,
+				salt,
+			} => Self::Create2 {
+				caller,
+				code_hash,
+				salt,
+			},
+			evm_runtime::CreateScheme::Fixed(address) => Self::Fixed(address),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub enum EvmEvent {
+	Call {
+		code_address: H160,
+		transfer: Option<Transfer>,
+		input: Vec<u8>,
+		target_gas: Option<u64>,
+		is_static: bool,
+		context: super::Context,
+	},
+	Create {
+		caller: H160,
+		address: H160,
+		scheme: CreateScheme,
+		value: U256,
+		init_code: Vec<u8>,
+		target_gas: Option<u64>,
+	},
+	Suicide {
+		address: H160,
+		target: H160,
+		balance: U256,
+	},
+	Exit {
+		reason: ExitReason,
+		return_value: Vec<u8>,
+	},
+	TransactCall {
+		caller: H160,
+		address: H160,
+		value: U256,
+		data: Vec<u8>,
+		gas_limit: u64,
+	},
+	TransactCreate {
+		caller: H160,
+		value: U256,
+		init_code: Vec<u8>,
+		gas_limit: u64,
+		address: H160,
+	},
+	TransactCreate2 {
+		caller: H160,
+		value: U256,
+		init_code: Vec<u8>,
+		salt: H256,
+		gas_limit: u64,
+		address: H160,
+	},
+}
+
+#[cfg(feature = "evm-tracing")]
+impl<'a> From<evm::tracing::Event<'a>> for EvmEvent {
+	fn from(i: evm::tracing::Event<'a>) -> Self {
+		match i {
+			evm::tracing::Event::Call {
+				code_address,
+				transfer,
+				input,
+				target_gas,
+				is_static,
+				context,
+			} => Self::Call {
+				code_address,
+				transfer: if let Some(transfer) = transfer {
+					Some(transfer.clone().into())
+				} else {
+					None
+				},
+				input: input.to_vec(),
+				target_gas,
+				is_static,
+				context: context.clone().into(),
+			},
+			evm::tracing::Event::Create {
+				caller,
+				address,
+				scheme,
+				value,
+				init_code,
+				target_gas,
+			} => Self::Create {
+				caller,
+				address,
+				scheme: scheme.into(),
+				value,
+				init_code: init_code.to_vec(),
+				target_gas,
+			},
+			evm::tracing::Event::Suicide {
+				address,
+				target,
+				balance,
+			} => Self::Suicide {
+				address,
+				target,
+				balance,
+			},
+			evm::tracing::Event::Exit {
+				reason,
+				return_value,
+			} => Self::Exit {
+				reason: reason.clone(),
+				return_value: return_value.to_vec(),
+			},
+			evm::tracing::Event::TransactCall {
+				caller,
+				address,
+				value,
+				data,
+				gas_limit,
+			} => Self::TransactCall {
+				caller,
+				address,
+				value,
+				data: data.to_vec(),
+				gas_limit,
+			},
+			evm::tracing::Event::TransactCreate {
+				caller,
+				value,
+				init_code,
+				gas_limit,
+				address,
+			} => Self::TransactCreate {
+				caller,
+				value,
+				init_code: init_code.to_vec(),
+				gas_limit,
+				address,
+			},
+			evm::tracing::Event::TransactCreate2 {
+				caller,
+				value,
+				init_code,
+				salt,
+				gas_limit,
+				address,
+			} => Self::TransactCreate2 {
+				caller,
+				value,
+				init_code: init_code.to_vec(),
+				salt,
+				gas_limit,
+				address,
+			},
+		}
+	}
+}

--- a/primitives/rpc/evm-tracing-events/src/gasometer.rs
+++ b/primitives/rpc/evm-tracing-events/src/gasometer.rs
@@ -1,4 +1,3 @@
-// [TODO] Should I remove the Moonbeam's license??
 // Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 

--- a/primitives/rpc/evm-tracing-events/src/gasometer.rs
+++ b/primitives/rpc/evm-tracing-events/src/gasometer.rs
@@ -1,0 +1,114 @@
+// [TODO] Should I remove the Moonbeam's license??
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use codec::{Decode, Encode};
+
+#[derive(Debug, Default, Copy, Clone, Encode, Decode, PartialEq, Eq)]
+pub struct Snapshot {
+	pub gas_limit: u64,
+	pub memory_gas: u64,
+	pub used_gas: u64,
+	pub refunded_gas: i64,
+}
+
+impl Snapshot {
+	pub fn gas(&self) -> u64 {
+		self.gas_limit - self.used_gas - self.memory_gas
+	}
+}
+
+impl From<Option<evm_gasometer::Snapshot>> for Snapshot {
+	fn from(i: Option<evm_gasometer::Snapshot>) -> Self {
+		if let Some(i) = i {
+			Self {
+				gas_limit: i.gas_limit,
+				memory_gas: i.memory_gas,
+				used_gas: i.used_gas,
+				refunded_gas: i.refunded_gas,
+			}
+		} else {
+			Default::default()
+		}
+	}
+}
+
+#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq)]
+pub enum GasometerEvent {
+	RecordCost {
+		cost: u64,
+		snapshot: Snapshot,
+	},
+	RecordRefund {
+		refund: i64,
+		snapshot: Snapshot,
+	},
+	RecordStipend {
+		stipend: u64,
+		snapshot: Snapshot,
+	},
+	RecordDynamicCost {
+		gas_cost: u64,
+		memory_gas: u64,
+		gas_refund: i64,
+		snapshot: Snapshot,
+	},
+	RecordTransaction {
+		cost: u64,
+		snapshot: Snapshot,
+	},
+}
+
+#[cfg(feature = "evm-tracing")]
+impl From<evm_gasometer::tracing::Event> for GasometerEvent {
+	fn from(i: evm_gasometer::tracing::Event) -> Self {
+		match i {
+			evm_gasometer::tracing::Event::RecordCost { cost, snapshot } => Self::RecordCost {
+				cost,
+				snapshot: snapshot.into(),
+			},
+			evm_gasometer::tracing::Event::RecordRefund { refund, snapshot } => {
+				Self::RecordRefund {
+					refund,
+					snapshot: snapshot.into(),
+				}
+			}
+			evm_gasometer::tracing::Event::RecordStipend { stipend, snapshot } => {
+				Self::RecordStipend {
+					stipend,
+					snapshot: snapshot.into(),
+				}
+			}
+			evm_gasometer::tracing::Event::RecordDynamicCost {
+				gas_cost,
+				memory_gas,
+				gas_refund,
+				snapshot,
+			} => Self::RecordDynamicCost {
+				gas_cost,
+				memory_gas,
+				gas_refund,
+				snapshot: snapshot.into(),
+			},
+			evm_gasometer::tracing::Event::RecordTransaction { cost, snapshot } => {
+				Self::RecordTransaction {
+					cost,
+					snapshot: snapshot.into(),
+				}
+			}
+		}
+	}
+}

--- a/primitives/rpc/evm-tracing-events/src/lib.rs
+++ b/primitives/rpc/evm-tracing-events/src/lib.rs
@@ -1,4 +1,3 @@
-// [TODO] Should I remove the Moonbeam's license??
 // Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 

--- a/primitives/rpc/evm-tracing-events/src/lib.rs
+++ b/primitives/rpc/evm-tracing-events/src/lib.rs
@@ -1,0 +1,285 @@
+// [TODO] Should I remove the Moonbeam's license??
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A Proxy in this context is an environmental trait implementor meant to be used for capturing
+//! EVM trace events sent to a Host function from the Runtime. Works like:
+//! - Runtime Api call `using` environmental.
+//! - Runtime calls a Host function with some scale-encoded Evm event.
+//! - Host function emits an additional event to this Listener.
+//! - Proxy listens for the event and format the actual trace response.
+//!
+//! There are two proxy types: `Raw` and `CallList`.
+//! - `Raw` - used for opcode-level traces.
+//! - `CallList` - used for block tracing (stack of call stacks) and custom tracing outputs.
+//!
+//! The EVM event types may contain references and not implement Encode/Decode.
+//! This module provide mirror types and conversion into them from the original events.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+pub mod evm;
+pub mod gasometer;
+pub mod runtime;
+
+pub use self::evm::EvmEvent;
+pub use gasometer::GasometerEvent;
+pub use runtime::RuntimeEvent;
+
+use ::evm::Opcode;
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use ethereum_types::{H160, U256};
+use sp_runtime_interface::pass_by::PassByCodec;
+
+environmental::environmental!(listener: dyn Listener + 'static);
+
+pub fn using<R, F: FnOnce() -> R>(l: &mut (dyn Listener + 'static), f: F) -> R {
+	listener::using(l, f)
+}
+
+/// Allow to configure which data of the Step event
+/// we want to keep or discard. Not discarding the data requires cloning the data
+/// in the runtime which have a significant cost for each step.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode, Default, PassByCodec)]
+pub struct StepEventFilter {
+	pub enable_stack: bool,
+	pub enable_memory: bool,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+pub enum Event {
+	Evm(evm::EvmEvent),
+	Gasometer(gasometer::GasometerEvent),
+	Runtime(runtime::RuntimeEvent),
+	CallListNew(),
+}
+
+impl Event {
+	/// Access the global reference and call it's `event` method, passing the `Event` itself as
+	/// argument.
+	///
+	/// This only works if we are `using` a global reference to a `Listener` implementor.
+	pub fn emit(self) {
+		listener::with(|listener| listener.event(self));
+	}
+}
+
+/// Main trait to proxy emitted messages.
+/// Used 2 times :
+/// - Inside the runtime to proxy the events throught the host functions
+/// - Inside the client to forward those events to the client listener.
+pub trait Listener {
+	fn event(&mut self, event: Event);
+
+	/// Allow the runtime to know which data should be discarded and not cloned.
+	/// WARNING: It is only called once when the runtime tracing is instanciated to avoid
+	/// performing many ext calls.
+	fn step_event_filter(&self) -> StepEventFilter;
+}
+
+pub fn step_event_filter() -> Option<StepEventFilter> {
+	let mut filter = None;
+	listener::with(|listener| filter = Some(listener.step_event_filter()));
+	filter
+}
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct Context {
+	/// Execution address.
+	pub address: H160,
+	/// Caller of the EVM.
+	pub caller: H160,
+	/// Apparent value of the EVM.
+	pub apparent_value: U256,
+}
+
+impl From<evm_runtime::Context> for Context {
+	fn from(i: evm_runtime::Context) -> Self {
+		Self {
+			address: i.address,
+			caller: i.caller,
+			apparent_value: i.apparent_value,
+		}
+	}
+}
+
+/// Converts an Opcode into its name, stored in a `Vec<u8>`.
+pub fn opcodes_string(opcode: Opcode) -> Vec<u8> {
+	let tmp;
+	let out = match opcode {
+		Opcode(0) => "Stop",
+		Opcode(1) => "Add",
+		Opcode(2) => "Mul",
+		Opcode(3) => "Sub",
+		Opcode(4) => "Div",
+		Opcode(5) => "SDiv",
+		Opcode(6) => "Mod",
+		Opcode(7) => "SMod",
+		Opcode(8) => "AddMod",
+		Opcode(9) => "MulMod",
+		Opcode(10) => "Exp",
+		Opcode(11) => "SignExtend",
+		Opcode(16) => "Lt",
+		Opcode(17) => "Gt",
+		Opcode(18) => "Slt",
+		Opcode(19) => "Sgt",
+		Opcode(20) => "Eq",
+		Opcode(21) => "IsZero",
+		Opcode(22) => "And",
+		Opcode(23) => "Or",
+		Opcode(24) => "Xor",
+		Opcode(25) => "Not",
+		Opcode(26) => "Byte",
+		Opcode(27) => "Shl",
+		Opcode(28) => "Shr",
+		Opcode(29) => "Sar",
+		Opcode(32) => "Keccak256",
+		Opcode(48) => "Address",
+		Opcode(49) => "Balance",
+		Opcode(50) => "Origin",
+		Opcode(51) => "Caller",
+		Opcode(52) => "CallValue",
+		Opcode(53) => "CallDataLoad",
+		Opcode(54) => "CallDataSize",
+		Opcode(55) => "CallDataCopy",
+		Opcode(56) => "CodeSize",
+		Opcode(57) => "CodeCopy",
+		Opcode(58) => "GasPrice",
+		Opcode(59) => "ExtCodeSize",
+		Opcode(60) => "ExtCodeCopy",
+		Opcode(61) => "ReturnDataSize",
+		Opcode(62) => "ReturnDataCopy",
+		Opcode(63) => "ExtCodeHash",
+		Opcode(64) => "BlockHash",
+		Opcode(65) => "Coinbase",
+		Opcode(66) => "Timestamp",
+		Opcode(67) => "Number",
+		Opcode(68) => "Difficulty",
+		Opcode(69) => "GasLimit",
+		Opcode(70) => "ChainId",
+		Opcode(80) => "Pop",
+		Opcode(81) => "MLoad",
+		Opcode(82) => "MStore",
+		Opcode(83) => "MStore8",
+		Opcode(84) => "SLoad",
+		Opcode(85) => "SStore",
+		Opcode(86) => "Jump",
+		Opcode(87) => "JumpI",
+		Opcode(88) => "GetPc",
+		Opcode(89) => "MSize",
+		Opcode(90) => "Gas",
+		Opcode(91) => "JumpDest",
+		Opcode(96) => "Push1",
+		Opcode(97) => "Push2",
+		Opcode(98) => "Push3",
+		Opcode(99) => "Push4",
+		Opcode(100) => "Push5",
+		Opcode(101) => "Push6",
+		Opcode(102) => "Push7",
+		Opcode(103) => "Push8",
+		Opcode(104) => "Push9",
+		Opcode(105) => "Push10",
+		Opcode(106) => "Push11",
+		Opcode(107) => "Push12",
+		Opcode(108) => "Push13",
+		Opcode(109) => "Push14",
+		Opcode(110) => "Push15",
+		Opcode(111) => "Push16",
+		Opcode(112) => "Push17",
+		Opcode(113) => "Push18",
+		Opcode(114) => "Push19",
+		Opcode(115) => "Push20",
+		Opcode(116) => "Push21",
+		Opcode(117) => "Push22",
+		Opcode(118) => "Push23",
+		Opcode(119) => "Push24",
+		Opcode(120) => "Push25",
+		Opcode(121) => "Push26",
+		Opcode(122) => "Push27",
+		Opcode(123) => "Push28",
+		Opcode(124) => "Push29",
+		Opcode(125) => "Push30",
+		Opcode(126) => "Push31",
+		Opcode(127) => "Push32",
+		Opcode(128) => "Dup1",
+		Opcode(129) => "Dup2",
+		Opcode(130) => "Dup3",
+		Opcode(131) => "Dup4",
+		Opcode(132) => "Dup5",
+		Opcode(133) => "Dup6",
+		Opcode(134) => "Dup7",
+		Opcode(135) => "Dup8",
+		Opcode(136) => "Dup9",
+		Opcode(137) => "Dup10",
+		Opcode(138) => "Dup11",
+		Opcode(139) => "Dup12",
+		Opcode(140) => "Dup13",
+		Opcode(141) => "Dup14",
+		Opcode(142) => "Dup15",
+		Opcode(143) => "Dup16",
+		Opcode(144) => "Swap1",
+		Opcode(145) => "Swap2",
+		Opcode(146) => "Swap3",
+		Opcode(147) => "Swap4",
+		Opcode(148) => "Swap5",
+		Opcode(149) => "Swap6",
+		Opcode(150) => "Swap7",
+		Opcode(151) => "Swap8",
+		Opcode(152) => "Swap9",
+		Opcode(153) => "Swap10",
+		Opcode(154) => "Swap11",
+		Opcode(155) => "Swap12",
+		Opcode(156) => "Swap13",
+		Opcode(157) => "Swap14",
+		Opcode(158) => "Swap15",
+		Opcode(159) => "Swap16",
+		Opcode(160) => "Log0",
+		Opcode(161) => "Log1",
+		Opcode(162) => "Log2",
+		Opcode(163) => "Log3",
+		Opcode(164) => "Log4",
+		Opcode(176) => "JumpTo",
+		Opcode(177) => "JumpIf",
+		Opcode(178) => "JumpSub",
+		Opcode(180) => "JumpSubv",
+		Opcode(181) => "BeginSub",
+		Opcode(182) => "BeginData",
+		Opcode(184) => "ReturnSub",
+		Opcode(185) => "PutLocal",
+		Opcode(186) => "GetLocal",
+		Opcode(225) => "SLoadBytes",
+		Opcode(226) => "SStoreBytes",
+		Opcode(227) => "SSize",
+		Opcode(240) => "Create",
+		Opcode(241) => "Call",
+		Opcode(242) => "CallCode",
+		Opcode(243) => "Return",
+		Opcode(244) => "DelegateCall",
+		Opcode(245) => "Create2",
+		Opcode(250) => "StaticCall",
+		Opcode(252) => "TxExecGas",
+		Opcode(253) => "Revert",
+		Opcode(254) => "Invalid",
+		Opcode(255) => "SelfDestruct",
+		Opcode(n) => {
+			tmp = alloc::format!("Unknown({})", n);
+			&tmp
+		}
+	};
+	out.as_bytes().to_vec()
+}

--- a/primitives/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/rpc/evm-tracing-events/src/runtime.rs
@@ -1,4 +1,3 @@
-// [TODO] Should I remove the Moonbeam's license??
 // Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 

--- a/primitives/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/rpc/evm-tracing-events/src/runtime.rs
@@ -1,0 +1,159 @@
+// [TODO] Should I remove the Moonbeam's license??
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate alloc;
+
+use crate::StepEventFilter;
+
+use super::{opcodes_string, Context};
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use ethereum_types::{H160, H256, U256};
+pub use evm::{ExitError, ExitReason, ExitSucceed, Opcode};
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct Stack {
+	pub data: Vec<H256>,
+	pub limit: u64,
+}
+
+impl From<&evm::Stack> for Stack {
+	fn from(i: &evm::Stack) -> Self {
+		Self {
+			data: i.data().clone(),
+			limit: i.limit() as u64,
+		}
+	}
+}
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct Memory {
+	pub data: Vec<u8>,
+	pub effective_len: U256,
+	pub limit: u64,
+}
+
+impl From<&evm::Memory> for Memory {
+	fn from(i: &evm::Memory) -> Self {
+		Self {
+			data: i.data().clone(),
+			effective_len: i.effective_len(),
+			limit: i.limit() as u64,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Encode, Decode)]
+pub enum Capture<E, T> {
+	/// The machine has exited. It cannot be executed again.
+	Exit(E),
+	/// The machine has trapped. It is waiting for external information, and can
+	/// be executed again.
+	Trap(T),
+}
+
+pub type Trap = Vec<u8>; // Should hold the marshalled Opcode.
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub enum RuntimeEvent {
+	Step {
+		context: Context,
+		// This needs to be marshalled in the runtime no matter what.
+		opcode: Vec<u8>,
+		// We can use ExitReason with `with-codec` feature,
+		position: Result<u64, ExitReason>,
+		stack: Option<Stack>,
+		memory: Option<Memory>,
+	},
+	StepResult {
+		result: Result<(), Capture<ExitReason, Trap>>,
+		return_value: Vec<u8>,
+	},
+	SLoad {
+		address: H160,
+		index: H256,
+		value: H256,
+	},
+	SStore {
+		address: H160,
+		index: H256,
+		value: H256,
+	},
+}
+
+#[cfg(feature = "evm-tracing")]
+impl RuntimeEvent {
+	pub fn from_evm_event<'a>(i: evm_runtime::tracing::Event<'a>, filter: StepEventFilter) -> Self {
+		match i {
+			evm_runtime::tracing::Event::Step {
+				context,
+				opcode,
+				position,
+				stack,
+				memory,
+			} => Self::Step {
+				context: context.clone().into(),
+				opcode: opcodes_string(opcode),
+				position: match position {
+					Ok(position) => Ok(*position as u64),
+					Err(e) => Err(e.clone()),
+				},
+				stack: if filter.enable_stack {
+					Some(stack.into())
+				} else {
+					None
+				},
+				memory: if filter.enable_memory {
+					Some(memory.into())
+				} else {
+					None
+				},
+			},
+			evm_runtime::tracing::Event::StepResult {
+				result,
+				return_value,
+			} => Self::StepResult {
+				result: match result {
+					Ok(_) => Ok(()),
+					Err(capture) => match capture {
+						evm::Capture::Exit(e) => Err(Capture::Exit(e.clone())),
+						evm::Capture::Trap(t) => Err(Capture::Trap(opcodes_string(*t))),
+					},
+				},
+				return_value: return_value.to_vec(),
+			},
+			evm_runtime::tracing::Event::SLoad {
+				address,
+				index,
+				value,
+			} => Self::SLoad {
+				address,
+				index,
+				value,
+			},
+			evm_runtime::tracing::Event::SStore {
+				address,
+				index,
+				value,
+			} => Self::SStore {
+				address,
+				index,
+				value,
+			},
+		}
+	}
+}

--- a/primitives/rpc/txpool/Cargo.toml
+++ b/primitives/rpc/txpool/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "peaq-rpc-primitives-txpool"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+// [TODO] Should we chang the License?
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.6.0"
+
+[dependencies]
+ethereum = { version = "0.11.1", default-features = false, features = [ "with-codec" ] }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-api = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-io = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"ethereum/std",
+	"sp-api/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/primitives/rpc/txpool/Cargo.toml
+++ b/primitives/rpc/txpool/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-rpc-primitives-txpool"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/primitives/rpc/txpool/Cargo.toml
+++ b/primitives/rpc/txpool/Cargo.toml
@@ -3,7 +3,7 @@ name = "peaq-rpc-primitives-txpool"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-// [TODO] Should we chang the License?
+# [TODO] Should we chang the License?
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.6.0"

--- a/primitives/rpc/txpool/src/lib.rs
+++ b/primitives/rpc/txpool/src/lib.rs
@@ -1,0 +1,52 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+// These clippy lints are disabled because the macro-generated code triggers them.
+#![allow(clippy::unnecessary_mut_passed)]
+#![allow(clippy::too_many_arguments)]
+
+use codec::{Decode, Encode};
+pub use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
+use sp_runtime::traits::Block as BlockT;
+use sp_std::vec::Vec;
+
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_runtime::RuntimeDebug)]
+pub struct TxPoolResponseLegacy {
+	pub ready: Vec<LegacyTransaction>,
+	pub future: Vec<LegacyTransaction>,
+}
+
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_runtime::RuntimeDebug)]
+pub struct TxPoolResponse {
+	pub ready: Vec<Transaction>,
+	pub future: Vec<Transaction>,
+}
+
+sp_api::decl_runtime_apis! {
+	#[api_version(2)]
+	pub trait TxPoolRuntimeApi {
+		#[changed_in(2)]
+		fn extrinsic_filter(
+			xt_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xt_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> TxPoolResponseLegacy;
+		fn extrinsic_filter(
+			xt_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xt_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> TxPoolResponse;
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -331,8 +331,7 @@ path = "../primitives/rpc/txpool"
 default-features = false
 
 [features]
-# default = ["std", "aura"]
-default = ["std", "aura", "evm-tracing"]
+default = ["std", "aura"]
 aura = []
 manual-seal = []
 runtime-benchmarks = [

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -331,7 +331,8 @@ path = "../primitives/rpc/txpool"
 default-features = false
 
 [features]
-default = ["std", "aura"]
+# default = ["std", "aura"]
+default = ["std", "aura", "evm-tracing"]
 aura = []
 manual-seal = []
 runtime-benchmarks = [

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,6 +29,16 @@ features = ['derive']
 optional = true
 version = '1.0.101'
 
+[dependencies.rlp]
+default-features = false
+optional = true
+version = '0.5'
+
+[dependencies.sha3]
+default-features = false
+optional = true
+version = '0.8'
+
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/peaqnetwork/substrate'
@@ -302,10 +312,23 @@ branch = 'peaq-polkadot-v0.9.16'
 
 
 # Tracing
-evm-tracing-events = { path = "../primitives/rpc/evm-tracing-events", optional = true, default-features = false }
-peaq-evm-tracer = { path = "evm_tracer", optional = true, default-features = false }
-peaq-rpc-primitives-debug = { path = "../primitives/rpc/debug", default-features = false }
-peaq-rpc-primitives-txpool = { path = "../primitives/rpc/txpool", default-features = false }
+[dependencies.evm-tracing-events]
+path = "../primitives/rpc/evm-tracing-events"
+optional = true
+default-features = false
+
+[dependencies.peaq-evm-tracer]
+path = "evm_tracer"
+optional = true
+default-features = false
+
+[dependencies.peaq-rpc-primitives-debug]
+path = "../primitives/rpc/debug"
+default-features = false
+
+[dependencies.peaq-rpc-primitives-txpool]
+path = "../primitives/rpc/txpool"
+default-features = false
 
 [features]
 default = ["std", "aura"]
@@ -370,4 +393,18 @@ std = [
 	'pallet-evm-precompile-sha3fips/std',
 	'sp-std/std',
 	'fp-rpc/std',
+
+	# Tracing
+	'evm-tracing-events/std',
+	'peaq-evm-tracer/std',
+	'peaq-rpc-primitives-debug/std',
+	'peaq-rpc-primitives-txpool/std',
+]
+
+# Must be enabled for tracing runtimes only
+evm-tracing = [
+	'evm-tracing-events',
+	'peaq-evm-tracer',
+	'rlp',
+	'sha3'
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ version = '3.0.0-polkadot-v0.9.16'
 description = 'A node of the peaq network.'
 authors = ['peaq network <https://github.com/peaqnetwork>']
 homepage = 'https://peaq.network/'
-edition = '2018'
+edition = '2021'
 license = 'Unlicense'
 publish = false
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
@@ -300,6 +300,12 @@ default-features = false
 git = 'https://github.com/peaqnetwork/frontier'
 branch = 'peaq-polkadot-v0.9.16'
 
+
+# Tracing
+evm-tracing-events = { path = "../primitives/rpc/evm-tracing-events", optional = true, default-features = false }
+peaq-evm-tracer = { path = "evm_tracer", optional = true, default-features = false }
+peaq-rpc-primitives-debug = { path = "../primitives/rpc/debug", default-features = false }
+peaq-rpc-primitives-txpool = { path = "../primitives/rpc/txpool", default-features = false }
 
 [features]
 default = ["std", "aura"]

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -3,15 +3,15 @@ name = "peaq-evm-tracer"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-// [TODO]
+# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"
 
 [dependencies]
 
-evm-tracing-events = { path = "../primitives/rpc/evm-tracing-events", default-features = false, features = [ "evm-tracing" ] }
-peaq-primitives-ext = { path = "../primitives/ext", default-features = false }
+evm-tracing-events = { path = "../../primitives/rpc/evm-tracing-events", default-features = false, features = [ "evm-tracing" ] }
+peaq-primitives-ext = { path = "../../primitives/ext", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
@@ -39,7 +39,7 @@ std = [
 	"evm/std",
 	"evm/with-serde",
 	"fp-evm/std",
-	"moonbeam-primitives-ext/std",
+	"peaq-primitives-ext/std",
 	"pallet-evm/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -3,7 +3,6 @@ name = "peaq-evm-tracer"
 authors = ['peaq network <https://github.com/peaqnetwork>']
 edition = "2021"
 homepage = 'https://peaq.network/'
-# [TODO]
 license = "GPL-3.0-only"
 repository = 'https://github.com/peaqnetwork/peaq-network-node/'
 version = "0.1.0"

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "peaq-evm-tracer"
+authors = ['peaq network <https://github.com/peaqnetwork>']
+edition = "2021"
+homepage = 'https://peaq.network/'
+// [TODO]
+license = "GPL-3.0-only"
+repository = 'https://github.com/peaqnetwork/peaq-network-node/'
+version = "0.1.0"
+
+[dependencies]
+
+evm-tracing-events = { path = "../primitives/rpc/evm-tracing-events", default-features = false, features = [ "evm-tracing" ] }
+peaq-primitives-ext = { path = "../primitives/ext", default-features = false }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
+sp-core = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-io = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-runtime = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+sp-std = { git = "https://github.com/peaqnetwork/substrate.git", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+# Frontier
+ethereum-types = { version = "0.12.1", default-features = false }
+evm = { version = "0.33.1", default-features = false, features = [ "with-codec" ] }
+evm-gasometer = { version = "0.33.0", default-features = false }
+evm-runtime = { version = "0.33.0", default-features = false }
+fp-evm = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16", default-features = false }
+pallet-evm = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v0.9.16", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"ethereum-types/std",
+	"evm-gasometer/std",
+	"evm-runtime/std",
+	"evm-tracing-events/std",
+	"evm/std",
+	"evm/with-serde",
+	"fp-evm/std",
+	"moonbeam-primitives-ext/std",
+	"pallet-evm/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/runtime/evm_tracer/src/lib.rs
+++ b/runtime/evm_tracer/src/lib.rs
@@ -1,0 +1,117 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Substrate EVM tracing.
+//!
+//! The purpose of this crate is enable tracing the EVM opcode execution and will be used by
+//! both Dapp developers - to get a granular view on their transactions - and indexers to access
+//! the EVM callstack (internal transactions).
+//!
+//! Proxies EVM messages to the host functions.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod tracer {
+	use codec::Encode;
+	use evm_tracing_events::{EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};
+
+	use evm::tracing::{using as evm_using, EventListener as EvmListener};
+	use evm_gasometer::tracing::{using as gasometer_using, EventListener as GasometerListener};
+	use evm_runtime::tracing::{using as runtime_using, EventListener as RuntimeListener};
+	use sp_std::{cell::RefCell, rc::Rc};
+
+	struct ListenerProxy<T>(pub Rc<RefCell<T>>);
+	impl<T: GasometerListener> GasometerListener for ListenerProxy<T> {
+		fn event(&mut self, event: evm_gasometer::tracing::Event) {
+			self.0.borrow_mut().event(event);
+		}
+	}
+
+	impl<T: RuntimeListener> RuntimeListener for ListenerProxy<T> {
+		fn event(&mut self, event: evm_runtime::tracing::Event) {
+			self.0.borrow_mut().event(event);
+		}
+	}
+
+	impl<T: EvmListener> EvmListener for ListenerProxy<T> {
+		fn event(&mut self, event: evm::tracing::Event) {
+			self.0.borrow_mut().event(event);
+		}
+	}
+
+	pub struct EvmTracer {
+		step_event_filter: StepEventFilter,
+	}
+
+	impl EvmTracer {
+		pub fn new() -> Self {
+			Self {
+				step_event_filter: peaq_primitives_ext::peaq_ext::step_event_filter(),
+			}
+		}
+
+		/// Setup event listeners and execute provided closure.
+		///
+		/// Consume the tracer and return it alongside the return value of
+		/// the closure.
+		pub fn trace<R, F: FnOnce() -> R>(self, f: F) {
+			let wrapped = Rc::new(RefCell::new(self));
+
+			let mut gasometer = ListenerProxy(Rc::clone(&wrapped));
+			let mut runtime = ListenerProxy(Rc::clone(&wrapped));
+			let mut evm = ListenerProxy(Rc::clone(&wrapped));
+
+			// Each line wraps the previous `f` into a `using` call.
+			// Listening to new events results in adding one new line.
+			// Order is irrelevant when registering listeners.
+			let f = || runtime_using(&mut runtime, f);
+			let f = || gasometer_using(&mut gasometer, f);
+			let f = || evm_using(&mut evm, f);
+			f();
+		}
+
+		pub fn emit_new() {
+			peaq_primitives_ext::peaq_ext::call_list_new();
+		}
+	}
+
+	impl EvmListener for EvmTracer {
+		/// Proxies `evm::tracing::Event` to the host.
+		fn event(&mut self, event: evm::tracing::Event) {
+			let event: EvmEvent = event.into();
+			let message = event.encode();
+			peaq_primitives_ext::peaq_ext::evm_event(message);
+		}
+	}
+
+	impl GasometerListener for EvmTracer {
+		/// Proxies `evm_gasometer::tracing::Event` to the host.
+		fn event(&mut self, event: evm_gasometer::tracing::Event) {
+			let event: GasometerEvent = event.into();
+			let message = event.encode();
+			peaq_primitives_ext::peaq_ext::gasometer_event(message);
+		}
+	}
+
+	impl RuntimeListener for EvmTracer {
+		/// Proxies `evm_runtime::tracing::Event` to the host.
+		fn event(&mut self, event: evm_runtime::tracing::Event) {
+			let event = RuntimeEvent::from_evm_event(event, self.step_event_filter);
+			let message = event.encode();
+			peaq_primitives_ext::peaq_ext::runtime_event(message);
+		}
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -431,7 +431,6 @@ impl pallet_dynamic_fee::Config for Runtime {
 
 frame_support::parameter_types! {
 	pub IsActive: bool = true;
-	// [TODO]...
 	pub DefaultBaseFeePerGas: U256 = U256::from(1024);
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 2,
+	spec_version: 3,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -641,7 +641,9 @@ impl_runtime_apis! {
 
 	impl peaq_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
 		fn trace_transaction(
+		    #[allow(unused_variables)]
 			extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+			#[allow(unused_variables)]
 			traced_transaction: &EthereumTransaction,
 		) -> Result<
 			(),
@@ -677,7 +679,9 @@ impl_runtime_apis! {
 		}
 
 		fn trace_block(
+			#[allow(unused_variables)]
 			extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+			#[allow(unused_variables)]
 			known_transactions: Vec<H256>,
 		) -> Result<
 			(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -57,6 +57,8 @@ mod precompiles;
 pub use precompiles::PeaqPrecompiles;
 pub type Precompiles = PeaqPrecompiles<Runtime>;
 
+use peaq_rpc_primitives_txpool::TxPoolResponse;
+
 pub use peaq_pallet_did;
 pub use peaq_pallet_transaction;
 
@@ -634,6 +636,108 @@ impl_runtime_apis! {
 	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
 		fn account_nonce(account: AccountId) -> Index {
 			System::account_nonce(account)
+		}
+	}
+
+	impl peaq_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
+		fn trace_transaction(
+			extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+			traced_transaction: &EthereumTransaction,
+		) -> Result<
+			(),
+			sp_runtime::DispatchError,
+		> {
+			#[cfg(feature = "evm-tracing")]
+			{
+				use peaq_evm_tracer::tracer::EvmTracer;
+				// Apply the a subset of extrinsics: all the substrate-specific or ethereum
+				// transactions that preceded the requested transaction.
+				for ext in extrinsics.into_iter() {
+					let _ = match &ext.0.function {
+						Call::Ethereum(transact { transaction }) => {
+							if transaction == traced_transaction {
+								EvmTracer::new().trace(|| Executive::apply_extrinsic(ext));
+								return Ok(());
+							} else {
+								Executive::apply_extrinsic(ext)
+							}
+						}
+						_ => Executive::apply_extrinsic(ext),
+					};
+				}
+
+				Err(sp_runtime::DispatchError::Other(
+					"Failed to find Ethereum transaction among the extrinsics.",
+				))
+			}
+			#[cfg(not(feature = "evm-tracing"))]
+			Err(sp_runtime::DispatchError::Other(
+				"Missing `evm-tracing` compile time feature flag.",
+			))
+		}
+
+		fn trace_block(
+			extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+			known_transactions: Vec<H256>,
+		) -> Result<
+			(),
+			sp_runtime::DispatchError,
+		> {
+			#[cfg(feature = "evm-tracing")]
+			{
+				use peaq_evm_tracer::tracer::EvmTracer;
+
+				let mut config = <Runtime as pallet_evm::Config>::config().clone();
+				config.estimate = true;
+
+				// Apply all extrinsics. Ethereum extrinsics are traced.
+				for ext in extrinsics.into_iter() {
+					match &ext.0.function {
+						Call::Ethereum(transact { transaction }) => {
+							if known_transactions.contains(&transaction.hash()) {
+								// Each known extrinsic is a new call stack.
+								EvmTracer::emit_new();
+								EvmTracer::new().trace(|| Executive::apply_extrinsic(ext));
+							} else {
+								let _ = Executive::apply_extrinsic(ext);
+							}
+						}
+						_ => {
+							let _ = Executive::apply_extrinsic(ext);
+						}
+					};
+				}
+
+				Ok(())
+			}
+			#[cfg(not(feature = "evm-tracing"))]
+			Err(sp_runtime::DispatchError::Other(
+				"Missing `evm-tracing` compile time feature flag.",
+			))
+		}
+	}
+
+	impl peaq_rpc_primitives_txpool::TxPoolRuntimeApi<Block> for Runtime {
+		fn extrinsic_filter(
+			xts_ready: Vec<<Block as BlockT>::Extrinsic>,
+			xts_future: Vec<<Block as BlockT>::Extrinsic>,
+		) -> TxPoolResponse {
+			TxPoolResponse {
+				ready: xts_ready
+					.into_iter()
+					.filter_map(|xt| match xt.0.function {
+						Call::Ethereum(transact { transaction }) => Some(transaction),
+						_ => None,
+					})
+					.collect(),
+				future: xts_future
+					.into_iter()
+					.filter_map(|xt| match xt.0.function {
+						Call::Ethereum(transact { transaction }) => Some(transaction),
+						_ => None,
+					})
+					.collect(),
+			}
 		}
 	}
 


### PR DESCRIPTION
1. Support the eth explorer by porting the Moonbeam's tracing/debug/txpool module
2. Increase the spec version because the node/runtime changed.
3. Because we are following Moonbeam's implementation, I keep Moonbeam's License in our code.
4. The solution documents haven't been ready yet.