### PR TITLE
Fix/1203466796723268 rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,35 +2257,14 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 [[package]]
 name = "evm"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8ff320c1e25e7f6d676858f16ffd9b0493d2cc67c3d900c6f2ed027b747f43"
-dependencies = [
- "auto_impl",
- "environmental",
- "ethereum",
- "evm-core 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "evm-gasometer 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "evm-runtime 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log",
- "parity-scale-codec",
- "primitive-types",
- "rlp",
- "scale-info",
- "serde",
- "sha3 0.10.1",
-]
-
-[[package]]
-name = "evm"
-version = "0.35.0"
 source = "git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29#27ac63fadb6e716cfcc275b4ddf0aed5c0624b18"
 dependencies = [
  "auto_impl",
  "environmental",
  "ethereum",
- "evm-core 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-gasometer 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-runtime 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm-core",
+ "evm-gasometer",
+ "evm-runtime",
  "log",
  "parity-scale-codec",
  "primitive-types",
@@ -2293,18 +2272,6 @@ dependencies = [
  "scale-info",
  "serde",
  "sha3 0.10.1",
-]
-
-[[package]]
-name = "evm-core"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4537041d3a3438d59b2d01bd950ce89fb1ccb3cf21d9331193c10be12e849f"
-dependencies = [
- "parity-scale-codec",
- "primitive-types",
- "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -2321,37 +2288,12 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6181da8734c86873ac9b3f9886d4e00105361039dcfb9f621be9a0ddb8f43961"
-dependencies = [
- "environmental",
- "evm-core 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "evm-runtime 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types",
-]
-
-[[package]]
-name = "evm-gasometer"
-version = "0.35.0"
 source = "git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29#27ac63fadb6e716cfcc275b4ddf0aed5c0624b18"
 dependencies = [
  "environmental",
- "evm-core 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-runtime 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm-core",
+ "evm-runtime",
  "primitive-types",
-]
-
-[[package]]
-name = "evm-runtime"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6157af91ca70fcf3581afaea1fa25974a71b9ef63d454c08dfba93ab0c7715d"
-dependencies = [
- "auto_impl",
- "environmental",
- "evm-core 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types",
- "sha3 0.10.1",
 ]
 
 [[package]]
@@ -2361,7 +2303,7 @@ source = "git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29#27
 dependencies = [
  "auto_impl",
  "environmental",
- "evm-core 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm-core",
  "primitive-types",
  "sha3 0.10.1",
 ]
@@ -2373,9 +2315,9 @@ dependencies = [
  "environmental",
  "ethereum",
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-gasometer 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-runtime 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
  "parity-scale-codec",
  "sp-runtime-interface",
 ]
@@ -2521,7 +2463,7 @@ source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.
 dependencies = [
  "ethereum",
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
  "fc-db",
  "fc-rpc-core",
  "fp-ethereum",
@@ -2725,7 +2667,7 @@ name = "fp-evm"
 version = "3.0.0-dev"
 source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.29#09a842865ce6190827a79a2690808fd349ad6ec7"
 dependencies = [
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
  "frame-support",
  "parity-scale-codec",
  "serde",
@@ -6032,7 +5974,7 @@ source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.
 dependencies = [
  "ethereum",
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
  "fp-consensus",
  "fp-ethereum",
  "fp-evm",
@@ -6058,7 +6000,7 @@ version = "6.0.0-dev"
 source = "git+https://github.com/peaqnetwork/frontier?branch=peaq-polkadot-v0.9.29#09a842865ce6190827a79a2690808fd349ad6ec7"
 dependencies = [
  "environmental",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
  "fp-evm",
  "frame-benchmarking",
  "frame-support",
@@ -7139,9 +7081,9 @@ name = "peaq-evm-tracer"
 version = "0.1.0"
 dependencies = [
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-gasometer 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
- "evm-runtime 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
  "evm-tracing-events",
  "fp-evm",
  "pallet-evm",
@@ -7355,7 +7297,7 @@ name = "peaq-primitives-xcm"
 version = "3.0.0-polkadot-v0.9.29"
 dependencies = [
  "bstringify",
- "evm 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm",
  "frame-support",
  "num_enum",
  "parity-scale-codec",
@@ -8820,7 +8762,7 @@ name = "precompile-utils"
 version = "0.1.0"
 dependencies = [
  "affix",
- "evm 0.35.0 (git+https://github.com/peaqnetwork/evm?branch=peaq-polkadot-v0.9.29)",
+ "evm",
  "fp-evm",
  "frame-support",
  "frame-system",

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -13,7 +13,7 @@ num_enum = { version = "0.5.1", default-features = false }
 sp-core = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.29", default-features = false }
 sp-runtime = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.29", default-features = false }
 sp-std = { git = "https://github.com/peaqnetwork/substrate", branch = "peaq-polkadot-v0.9.29", default-features = false }
-evm = { version = "0.35.0", default-features = false, features = ["with-codec"] }
+evm = { git = "https://github.com/peaqnetwork/evm", branch = "peaq-polkadot-v0.9.29", default-features = false, features = [ "with-codec" ] }
 scale-info = { version = "2.1", default-features = false, features = ["derive"] }
 sha3 = { version = "0.9.1", default-features = false }
 serde_json = { version = "1.0" }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2022-09-10"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
1. Add the rust nightly version to avoid the build fails
2. Change the dependency to our peaq library, but not the native library.