### PR TITLE
Fix/1203466796723268 rust version standaone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8683,7 +8683,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2022-09-10"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
1. Limit the rust compiler to avoid a compilation error.
2. Revert the uncertainty change back