### PR TITLE
Update the dev branch for peaq pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7290,7 +7290,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-did"
 version = "0.0.2"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=peaq-polkadot-v0.9.29#64f2ef1ea3cbae6acb351d869c6b588c5cb504ca"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=dev#f0897816ccc57d8dfeda273b77d6a3b19059b8fe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-did-rpc"
 version = "0.0.2"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=peaq-polkadot-v0.9.29#64f2ef1ea3cbae6acb351d869c6b588c5cb504ca"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=dev#f0897816ccc57d8dfeda273b77d6a3b19059b8fe"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -7328,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-did-runtime-api"
 version = "0.0.2"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=peaq-polkadot-v0.9.29#64f2ef1ea3cbae6acb351d869c6b588c5cb504ca"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-did.git?branch=dev#f0897816ccc57d8dfeda273b77d6a3b19059b8fe"
 dependencies = [
  "parity-scale-codec",
  "peaq-pallet-did",
@@ -7339,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-rbac"
 version = "0.0.2"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-rbac.git?branch=peaq-polkadot-v0.9.29#ab4f672f1bdcabd6b98a689047e88497000cde83"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-rbac.git?branch=dev#13cbe0d5d360c263cade6f9a4d54c4e72d5db23b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7356,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-storage"
 version = "0.1.1"
-source = "git+https://github.com/peaqnetwork/peaq-storage-pallet.git?branch=peaq-polkadot-v0.9.29#7defa8367f07074a0bac92f9d126546280fa3402"
+source = "git+https://github.com/peaqnetwork/peaq-storage-pallet.git?branch=dev#5726eef2486a1d0f6d464b13003aa5dd6a8bcf2b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7372,7 +7372,7 @@ dependencies = [
 [[package]]
 name = "peaq-pallet-transaction"
 version = "0.0.2"
-source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?branch=peaq-polkadot-v0.9.29#7c5d3066aab16acb6456af49c26dc6eedfefd246"
+source = "git+https://github.com/peaqnetwork/peaq-pallet-transaction.git?branch=dev#7bb3fad4d08b0c525a60ffc984182aa17eaa405f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -375,7 +375,7 @@ branch = "peaq-polkadot-v0.9.29"
 
 [dependencies.peaq-pallet-did-rpc]
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 

--- a/runtime/agung/Cargo.toml
+++ b/runtime/agung/Cargo.toml
@@ -191,31 +191,31 @@ branch = 'peaq-polkadot-v0.9.29'
 [dependencies.peaq-pallet-did]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-did-runtime-api]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-transaction]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-transaction.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-rbac]
 git = 'https://github.com/peaqnetwork/peaq-pallet-rbac.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-storage]
 git = 'https://github.com/peaqnetwork/peaq-storage-pallet.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.1.1'
 
 [dependencies.pallet-multisig]

--- a/runtime/krest/Cargo.toml
+++ b/runtime/krest/Cargo.toml
@@ -191,31 +191,31 @@ branch = 'peaq-polkadot-v0.9.29'
 [dependencies.peaq-pallet-did]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-did-runtime-api]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-transaction]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-transaction.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-rbac]
 git = 'https://github.com/peaqnetwork/peaq-pallet-rbac.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-storage]
 git = 'https://github.com/peaqnetwork/peaq-storage-pallet.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.1.1'
 
 [dependencies.pallet-multisig]

--- a/runtime/peaq-dev/Cargo.toml
+++ b/runtime/peaq-dev/Cargo.toml
@@ -191,31 +191,31 @@ branch = 'peaq-polkadot-v0.9.29'
 [dependencies.peaq-pallet-did]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-did-runtime-api]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-did.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-transaction]
 default-features = false
 git = 'https://github.com/peaqnetwork/peaq-pallet-transaction.git'
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-rbac]
 git = 'https://github.com/peaqnetwork/peaq-pallet-rbac.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.0.2'
 
 [dependencies.peaq-pallet-storage]
 git = 'https://github.com/peaqnetwork/peaq-storage-pallet.git'
 default-features = false
-branch = 'peaq-polkadot-v0.9.29'
+branch = 'dev'
 version = '0.1.1'
 
 


### PR DESCRIPTION
After we merge the branch in the Peaq-related pallet, we have to use the dev branch.