### PR TITLE
Feat/1203985586459533 create common library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,6 +7184,7 @@ dependencies = [
  "polkadot-runtime-common",
  "precompile-utils",
  "rlp",
+ "runtime-common",
  "scale-info",
  "sha3 0.8.2",
  "smallvec",
@@ -7297,6 +7298,7 @@ dependencies = [
  "polkadot-runtime-common",
  "precompile-utils",
  "rlp",
+ "runtime-common",
  "scale-info",
  "sha3 0.8.2",
  "smallvec",
@@ -7414,6 +7416,7 @@ dependencies = [
  "polkadot-runtime-common",
  "precompile-utils",
  "rlp",
+ "runtime-common",
  "scale-info",
  "sha3 0.8.2",
  "smallvec",
@@ -7499,6 +7502,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
+ "runtime-common",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",
@@ -7990,6 +7994,7 @@ dependencies = [
  "polkadot-runtime-common",
  "precompile-utils",
  "rlp",
+ "runtime-common",
  "scale-info",
  "sha3 0.8.2",
  "smallvec",
@@ -10036,6 +10041,16 @@ checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "runtime-common"
+version = "0.0.1"
+dependencies = [
+ "pallet-transaction-payment",
+ "peaq-primitives-xcm",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -396,6 +396,9 @@ branch = "peaq-polkadot-v0.9.29"
 [dependencies.peaq-primitives-xcm]
 path = "../primitives/xcm"
 
+[dependencies.runtime-common]
+path = "../runtime/common"
+
 [dependencies.peaq-pallet-storage-rpc]
 git = 'https://github.com/peaqnetwork/peaq-storage-pallet.git'
 branch = 'dev'

--- a/node/src/parachain/agung_chain_spec.rs
+++ b/node/src/parachain/agung_chain_spec.rs
@@ -1,9 +1,13 @@
 use crate::parachain::Extensions;
 use cumulus_primitives_core::ParaId;
 use peaq_agung_runtime::{
-	staking, AccountId, Balance, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
+	staking, AccountId, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
 	EthereumConfig, GenesisAccount, GenesisConfig, ParachainInfoConfig, ParachainStakingConfig,
-	Precompiles, SudoConfig, SystemConfig, DOLLARS, MILLICENTS, TOKEN_DECIMALS, WASM_BINARY,
+	Precompiles, SudoConfig, SystemConfig, WASM_BINARY,
+};
+use runtime_common::{
+	DOLLARS, MILLICENTS, TOKEN_DECIMALS,
+	Balance,
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -1,10 +1,14 @@
 use crate::parachain::Extensions;
 use cumulus_primitives_core::ParaId;
 use peaq_dev_runtime::{
-	staking, AccountId, Balance, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
+	staking, AccountId, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
 	EthereumConfig, GenesisAccount, GenesisConfig, MorConfig, ParachainInfoConfig,
-	ParachainStakingConfig, PeaqMorConfig, Precompiles, Signature, SudoConfig, SystemConfig, CENTS,
-	DOLLARS, MILLICENTS, TOKEN_DECIMALS, WASM_BINARY,
+	ParachainStakingConfig, PeaqMorConfig, Precompiles, Signature, SudoConfig, SystemConfig,
+	WASM_BINARY,
+};
+use runtime_common::{
+	CENTS, DOLLARS, MILLICENTS, TOKEN_DECIMALS,
+	Balance,
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/node/src/parachain/krest_chain_spec.rs
+++ b/node/src/parachain/krest_chain_spec.rs
@@ -1,9 +1,13 @@
 use crate::parachain::Extensions;
 use cumulus_primitives_core::ParaId;
 use peaq_krest_runtime::{
-	staking, AccountId, Balance, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
+	staking, AccountId, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
 	EthereumConfig, GenesisAccount, GenesisConfig, ParachainInfoConfig, ParachainStakingConfig,
-	Precompiles, SudoConfig, SystemConfig, DOLLARS, MILLICENTS, TOKEN_DECIMALS, WASM_BINARY,
+	Precompiles, SudoConfig, SystemConfig, WASM_BINARY,
+};
+use runtime_common::{
+	DOLLARS, MILLICENTS, TOKEN_DECIMALS,
+	Balance,
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/node/src/parachain/peaq_chain_spec.rs
+++ b/node/src/parachain/peaq_chain_spec.rs
@@ -1,9 +1,13 @@
 use crate::parachain::Extensions;
 use cumulus_primitives_core::ParaId;
 use peaq_runtime::{
-	staking, AccountId, Balance, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
+	staking, AccountId, BalancesConfig, BlockRewardConfig, CouncilConfig, EVMConfig,
 	EthereumConfig, GenesisAccount, GenesisConfig, ParachainInfoConfig, ParachainStakingConfig,
-	Precompiles, SudoConfig, SystemConfig, DOLLARS, MILLICENTS, TOKEN_DECIMALS, WASM_BINARY,
+	Precompiles, SudoConfig, SystemConfig, WASM_BINARY,
+};
+use runtime_common::{
+	DOLLARS, MILLICENTS, TOKEN_DECIMALS,
+	Balance,
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/runtime/agung/Cargo.toml
+++ b/runtime/agung/Cargo.toml
@@ -222,7 +222,6 @@ default-features = false
 git = 'https://github.com/peaqnetwork/substrate'
 branch = 'peaq-polkadot-v0.9.29'
 
-
 [dependencies.pallet-utility]
 default-features = false
 git = 'https://github.com/peaqnetwork/substrate'
@@ -478,6 +477,11 @@ default-features = false
 path = "../../precompiles/utils"
 default-features = false
 
+[dependencies.runtime-common]
+path = "../common"
+default-features = false
+
+
 [features]
 default = ["std", "aura"]
 aura = []
@@ -522,7 +526,6 @@ std = [
 	'pallet-transaction-payment-rpc-runtime-api/std',
 	'pallet-transaction-payment/std',
 	'pallet-multisig/std',
-	'pallet-utility/std',
 	'sp-api/std',
 	'sp-block-builder/std',
 	'sp-consensus-aura/std',
@@ -543,8 +546,10 @@ std = [
 	'peaq-pallet-rbac/std',
 	'peaq-pallet-rbac-runtime-api/std',
 	'peaq-pallet-storage/std',
+	'peaq-pallet-storage-runtime-api/std',
+	'pallet-utility/std',
 	'pallet-treasury/std',
-	'pallet-collective/std', 
+	'pallet-collective/std',
 	'pallet-vesting/std',
 
 	# ETH support
@@ -600,9 +605,7 @@ std = [
 	# Customized
 	"peaq-primitives-xcm/std",
 	"precompile-utils/std",
-
-	"peaq-pallet-storage/std",
-	"peaq-pallet-storage-runtime-api/std"
+	"runtime-common/std",
 ]
 
 # Must be enabled for tracing runtimes only

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -641,8 +641,7 @@ parameter_types! {
 	pub const ChainId: u64 = 9999;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256
-		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -126,9 +126,6 @@ pub type AccountId = peaq_primitives_xcm::AccountId;
 /// never know...
 // type AccountIndex = peaq_primitives_xcm::AccountIndex;
 
-/// Balance of an account.
-pub type Balance = peaq_primitives_xcm::Balance;
-
 /// Index of a transaction in the chain.
 type Index = peaq_primitives_xcm::Nonce;
 
@@ -190,11 +187,11 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-// Contracts price units.
-pub const TOKEN_DECIMALS: u32 = 18;
-pub const MILLICENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2 - 3);
-pub const CENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2);
-pub const DOLLARS: Balance = 10_u128.pow(TOKEN_DECIMALS);
+use runtime_common::{
+	MILLICENTS, CENTS, DOLLARS,
+	Balance,
+	EoTFeeFactor, TransactionByteFee, OperationalFeeMultiplier,
+};
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
@@ -391,20 +388,6 @@ impl pallet_balances::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
-	pub const OperationalFeeMultiplier: u8 = 5;
-	pub const EoTFeeFactor: Perbill = Perbill::from_percent(50);
-}
-
-// Config the utility in pallets/utility
-impl pallet_utility::Config for Runtime {
-	type Call = Call;
-	type Event = Event;
-	type PalletsOrigin = OriginCaller;
-	type WeightInfo = ();
-}
-
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.
 ///
@@ -550,6 +533,14 @@ impl peaq_pallet_did::Config for Runtime {
 	type WeightInfo = peaq_pallet_did::weights::SubstrateWeight<Runtime>;
 }
 
+// Config the utility in pallets/utility
+impl pallet_utility::Config for Runtime {
+	type Call = Call;
+	type Event = Event;
+	type PalletsOrigin = OriginCaller;
+	type WeightInfo = ();
+}
+
 parameter_types! {
 	pub const CouncilMotionDuration: BlockNumber = 5 * DAYS;
 	pub const CouncilMaxProposals: u32 = 100;
@@ -576,7 +567,7 @@ parameter_types! {
 	pub const Burn: Permill = Permill::from_percent(50);
 	pub const TipCountdown: BlockNumber = DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
-	pub const TipReportDepositBase: Balance =  DOLLARS;
+	pub const TipReportDepositBase: Balance = DOLLARS;
 	pub const DataDepositPerByte: Balance = CENTS;
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const MaximumReasonLength: u32 = 300;
@@ -650,7 +641,8 @@ parameter_types! {
 	pub const ChainId: u64 = 9999;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub BlockGasLimit: U256
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 
@@ -738,7 +730,6 @@ impl cumulus_pallet_aura_ext::Config for Runtime {}
 parameter_types! {
 	pub const PotStakeId: PalletId = PalletId(*b"PotStake");
 	pub const PotTreasuryId: PalletId = TreasuryPalletId::get();
-
 }
 
 parameter_types! {
@@ -838,6 +829,7 @@ impl parachain_staking::Config for Runtime {
 }
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
+
 /// Implements the adapters for depositing unbalanced tokens on pots
 /// of various pallets, e.g. Peaq-MOR, Peaq-Treasury etc.
 macro_rules! impl_to_pot_adapter {

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = 'runtime-common'
+version = '0.0.1'
+description = 'A node of the peaq network.'
+authors = ['peaq network <https://github.com/peaqnetwork>']
+homepage = 'https://peaq.network/'
+edition = '2021'
+publish = false
+
+[dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.29'
+
+[dependencies.sp-std]
+default-features = false
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.29'
+
+[dependencies.pallet-transaction-payment]
+default-features = false
+git = 'https://github.com/peaqnetwork/substrate'
+branch = 'peaq-polkadot-v0.9.29'
+
+# Customized
+[dependencies.peaq-primitives-xcm]
+path = "../../primitives/xcm"
+default-features = false
+
+[features]
+default = ["std"]
+std = [
+	'sp-runtime/std',
+	'pallet-transaction-payment/std',
+	"peaq-primitives-xcm/std",
+]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,0 +1,23 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![recursion_limit = "256"]
+
+
+use sp_runtime::{
+	parameter_types, Perbill,
+};
+
+
+/// Balance of an account.
+pub type Balance = peaq_primitives_xcm::Balance;
+
+// Contracts price units.
+pub const TOKEN_DECIMALS: u32 = 18;
+pub const MILLICENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2 - 3);
+pub const CENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2);
+pub const DOLLARS: Balance = 10_u128.pow(TOKEN_DECIMALS);
+
+parameter_types! {
+	pub const TransactionByteFee: Balance = MILLICENTS;
+	pub const OperationalFeeMultiplier: u8 = 5;
+	pub const EoTFeeFactor: Perbill = Perbill::from_percent(50);
+}

--- a/runtime/krest/Cargo.toml
+++ b/runtime/krest/Cargo.toml
@@ -477,6 +477,10 @@ default-features = false
 path = "../../precompiles/utils"
 default-features = false
 
+[dependencies.runtime-common]
+path = "../common"
+default-features = false
+
 
 [features]
 default = ["std", "aura"]
@@ -545,9 +549,9 @@ std = [
 	'peaq-pallet-storage-runtime-api/std',
 	'pallet-utility/std',
 	'pallet-treasury/std',
-	'pallet-collective/std', 
+	'pallet-collective/std',
 	'pallet-vesting/std',
-	
+
 	# ETH support
 	'sp-io/std',
 	'fp-evm/std',
@@ -601,6 +605,7 @@ std = [
 	# Customized
 	"peaq-primitives-xcm/std",
 	"precompile-utils/std",
+	"runtime-common/std",
 ]
 
 # Must be enabled for tracing runtimes only

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -126,9 +126,6 @@ pub type AccountId = peaq_primitives_xcm::AccountId;
 /// never know...
 // type AccountIndex = peaq_primitives_xcm::AccountIndex;
 
-/// Balance of an account.
-pub type Balance = peaq_primitives_xcm::Balance;
-
 /// Index of a transaction in the chain.
 type Index = peaq_primitives_xcm::Nonce;
 
@@ -190,11 +187,11 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-// Contracts price units.
-pub const TOKEN_DECIMALS: u32 = 18;
-pub const MILLICENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2 - 3);
-pub const CENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2);
-pub const DOLLARS: Balance = 10_u128.pow(TOKEN_DECIMALS);
+use runtime_common::{
+	MILLICENTS, CENTS, DOLLARS,
+	Balance,
+	EoTFeeFactor, TransactionByteFee, OperationalFeeMultiplier,
+};
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
@@ -397,12 +394,6 @@ impl pallet_balances::Config for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
-}
-
-parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
-	pub const OperationalFeeMultiplier: u8 = 5;
-	pub const EoTFeeFactor: Perbill = Perbill::from_percent(50);
 }
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
@@ -658,7 +649,8 @@ parameter_types! {
 	pub const ChainId: u64 = 424242;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub BlockGasLimit: U256
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -649,8 +649,7 @@ parameter_types! {
 	pub const ChainId: u64 = 424242;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256
-		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 

--- a/runtime/peaq-dev/Cargo.toml
+++ b/runtime/peaq-dev/Cargo.toml
@@ -482,6 +482,11 @@ default-features = false
 path = "../../precompiles/utils"
 default-features = false
 
+[dependencies.runtime-common]
+path = "../common"
+default-features = false
+
+
 [features]
 default = ["std", "aura"]
 aura = []
@@ -547,13 +552,12 @@ std = [
 	'peaq-pallet-rbac/std',
 	'peaq-pallet-rbac-runtime-api/std',
 	'peaq-pallet-storage/std',
+	'peaq-pallet-storage-runtime-api/std',
 	'peaq-pallet-mor/std',
 	'pallet-utility/std',
-	'peaq-pallet-storage-runtime-api/std',
 	'pallet-treasury/std',
 	'pallet-collective/std',
 	'pallet-vesting/std',
- 
 
 	# ETH support
 	'sp-io/std',
@@ -608,6 +612,7 @@ std = [
 	# Customized
 	"peaq-primitives-xcm/std",
 	"precompile-utils/std",
+	"runtime-common/std",
 ]
 
 # Must be enabled for tracing runtimes only

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-//use core::cmp::max_by;
 #[cfg(feature = "std")]
 pub use fp_evm::GenesisAccount;
 
@@ -61,6 +60,7 @@ pub use frame_support::{
 	},
 	ConsensusEngineId, PalletId, StorageValue,
 };
+
 use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot, EnsureRootWithSuccess,
@@ -129,9 +129,6 @@ pub type AccountId = peaq_primitives_xcm::AccountId;
 /// never know...
 // type AccountIndex = peaq_primitives_xcm::AccountIndex;
 
-/// Balance of an account.
-pub type Balance = peaq_primitives_xcm::Balance;
-
 /// Index of a transaction in the chain.
 type Index = peaq_primitives_xcm::Nonce;
 
@@ -193,11 +190,11 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-// Contracts price units.
-pub const TOKEN_DECIMALS: u32 = 18;
-pub const MILLICENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2 - 3);
-pub const CENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2);
-pub const DOLLARS: Balance = 10_u128.pow(TOKEN_DECIMALS);
+use runtime_common::{
+	MILLICENTS, CENTS, DOLLARS,
+	Balance,
+	EoTFeeFactor, TransactionByteFee, OperationalFeeMultiplier,
+};
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
@@ -392,12 +389,6 @@ impl pallet_balances::Config for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
-}
-
-parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
-	pub const OperationalFeeMultiplier: u8 = 5;
-	pub const EoTFeeFactor: Perbill = Perbill::from_percent(50);
 }
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
@@ -653,7 +644,8 @@ parameter_types! {
 	pub const ChainId: u64 = 9999;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub BlockGasLimit: U256
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 
@@ -994,8 +986,6 @@ construct_runtime!(
 		Utility: pallet_utility::{Pallet, Call, Event} = 8,
 		Treasury: pallet_treasury  = 9,
 		Council: pallet_collective::<Instance1>=10,
-
-
 
 		// EVM
 		Ethereum: pallet_ethereum::{Pallet, Call, Storage, Event, Config, Origin} = 11,

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -644,8 +644,7 @@ parameter_types! {
 	pub const ChainId: u64 = 9999;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256
-		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 

--- a/runtime/peaq/Cargo.toml
+++ b/runtime/peaq/Cargo.toml
@@ -477,6 +477,10 @@ default-features = false
 path = "../../precompiles/utils"
 default-features = false
 
+[dependencies.runtime-common]
+path = "../common"
+default-features = false
+
 
 [features]
 default = ["std", "aura"]
@@ -601,6 +605,7 @@ std = [
 	# Customized
 	"peaq-primitives-xcm/std",
 	"precompile-utils/std",
+	"runtime-common/std",
 ]
 
 # Must be enabled for tracing runtimes only

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -126,9 +126,6 @@ pub type AccountId = peaq_primitives_xcm::AccountId;
 /// never know...
 // type AccountIndex = peaq_primitives_xcm::AccountIndex;
 
-/// Balance of an account.
-pub type Balance = peaq_primitives_xcm::Balance;
-
 /// Index of a transaction in the chain.
 type Index = peaq_primitives_xcm::Nonce;
 
@@ -190,11 +187,11 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-// Contracts price units.
-pub const TOKEN_DECIMALS: u32 = 18;
-pub const MILLICENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2 - 3);
-pub const CENTS: Balance = 10_u128.pow(TOKEN_DECIMALS - 2);
-pub const DOLLARS: Balance = 10_u128.pow(TOKEN_DECIMALS);
+use runtime_common::{
+	MILLICENTS, CENTS, DOLLARS,
+	Balance,
+	EoTFeeFactor, TransactionByteFee, OperationalFeeMultiplier,
+};
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
@@ -397,12 +394,6 @@ impl pallet_balances::Config for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
-}
-
-parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
-	pub const OperationalFeeMultiplier: u8 = 5;
-	pub const EoTFeeFactor: Perbill = Perbill::from_percent(50);
 }
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
@@ -654,7 +645,8 @@ parameter_types! {
 	pub const ChainId: u64 = 42424242;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
+	pub BlockGasLimit: U256
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -645,8 +645,7 @@ parameter_types! {
 	pub const ChainId: u64 = 42424242;
 	// WeightPerGas didn't use
 	pub NoUseWeightPerGas: u64 = 20_000;
-	pub BlockGasLimit: U256
-		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 	pub PrecompilesValue: PeaqPrecompiles<Runtime> = PeaqPrecompiles::<_>::new();
 }
 


### PR DESCRIPTION
Extract the runtime library.

I extracted part of the parameters because I assumed we had to add the fee modifier for the security issue. However, we don't need to do anything about the security issue during the clarification. But it can be the first step toward the common runtime module extraction.