### PR TITLE
Bug/1204493434055528 migrate max collator staking

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -145,6 +145,7 @@
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 pub mod default_weights;
+pub mod migrations;
 
 #[cfg(test)]
 pub(crate) mod mock;
@@ -202,7 +203,7 @@ pub mod pallet {
 	pub(crate) const STAKING_ID: LockIdentifier = *b"kiltpstk";
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
 
 	/// Pallet for parachain staking.
 	#[pallet::pallet]

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -1,37 +1,63 @@
-use log::{info};
+use crate::{types::BalanceOf, *};
+use frame_support::{
+	traits::{Get, GetStorageVersion, OnRuntimeUpgrade},
+	LOG_TARGET,
+};
+use log::info;
+use sp_runtime::traits::Saturating;
 
 pub mod v7 {
 	use super::*;
-	#[cfg(feature = "try-runtime")]
-	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
-		assert!(StorageVersion::<T>::get() == Releases::V7, "Storage version too high.");
+	pub struct MigrateToV8<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV8<T> {
+		#[cfg(feature = "try-runtime")]
+		pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+			assert!(Pallet::<T>::current_storage_version() == 7, "Storage version too high.");
 
-		log::debug!(
-			target: "runtime::parachain_staking",
-			"migration: Parachain_staking storage version v1 PRE migration checks succesful!"
-		);
+			log::debug!(
+				target: "runtime::parachain_staking",
+				"migration: Parachain_staking storage version v1 PRE migration checks succesful!"
+			);
 
-		Ok(())
+			Ok(())
+		}
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			let onchain = Pallet::<T>::on_chain_storage_version();
+			let current = Pallet::<T>::current_storage_version();
+			if onchain == 7 && current == 8 {
+				let max_collator_candidate_stake: BalanceOf<T> =
+					T::MinCollatorCandidateStake::get();
+				MaxCollatorCandidateStake::<T>::put(
+					max_collator_candidate_stake.saturating_mul(10_000u32.into()),
+				);
+				log::info!(
+					"Running migration with current storage version {:?} / onchain {:?}",
+					current,
+					onchain
+				);
+
+				info!(
+					target: LOG_TARGET,
+					" <<< Update the MaxCollatorCandidateStake ✅, {:?}",
+					max_collator_candidate_stake
+				);
+				// Return the weight consumed by the migration.
+				T::DbWeight::get().reads_writes(3, 1)
+			} else {
+				T::DbWeight::get().reads_writes(2, 0)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 8);
+			info!(
+				target: LOG_TARGET,
+				" <<< Show the MaxCollatorCandidateStake ✅, {:?}",
+				MaxCollatorCandidateStake::<T>::get()
+			);
+			// Return the weight consumed by the migration.
+			Ok(())
+		}
 	}
-
-	pub fn migrate<T: Config>() -> Weight {
-		let onchain_version =  Pallet::<T>::on_chain_storage_version();
-		// migrate to v8
-		let max_collator_candidate_stake = MinCollatorCandidateStake::<T>::get() * 1000;
-
-		MaxCollatorCandidateStake::<T>::put(max_collator_candidate_stake);
-
-		info!(target: LOG_TARGET," <<< Update the MaxCollatorCandidateStake ✅", max_collator_candidate_stake);
-		// Return the weight consumed by the migration.
-		T::DbWeight::get().reads_writes(1, 1)
-	}
-
-	#[cfg(feature = "try-runtime")]
-	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
-		assert_eq!(StorageVersion::<T>::get(), Releases::V8);
-		info!(target: LOG_TARGET," <<< Show the MaxCollatorCandidateStake ✅", MaxCollatorCandidateStake::<T>::get());
-		// Return the weight consumed by the migration.
-		Ok(())
-	}
-
 }

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -1,0 +1,37 @@
+use log::{info};
+
+pub mod v7 {
+	use super::*;
+	#[cfg(feature = "try-runtime")]
+	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+		assert!(StorageVersion::<T>::get() == Releases::V7, "Storage version too high.");
+
+		log::debug!(
+			target: "runtime::parachain_staking",
+			"migration: Parachain_staking storage version v1 PRE migration checks succesful!"
+		);
+
+		Ok(())
+	}
+
+	pub fn migrate<T: Config>() -> Weight {
+		let onchain_version =  Pallet::<T>::on_chain_storage_version();
+		// migrate to v8
+		let max_collator_candidate_stake = MinCollatorCandidateStake::<T>::get() * 1000;
+
+		MaxCollatorCandidateStake::<T>::put(max_collator_candidate_stake);
+
+		info!(target: LOG_TARGET," <<< Update the MaxCollatorCandidateStake ✅", max_collator_candidate_stake);
+		// Return the weight consumed by the migration.
+		T::DbWeight::get().reads_writes(1, 1)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
+		assert_eq!(StorageVersion::<T>::get(), Releases::V8);
+		info!(target: LOG_TARGET," <<< Show the MaxCollatorCandidateStake ✅", MaxCollatorCandidateStake::<T>::get());
+		// Return the weight consumed by the migration.
+		Ok(())
+	}
+
+}

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -762,8 +762,6 @@ impl pallet_session::Config for Runtime {
 pub mod staking {
 	use super::*;
 
-	pub const MAX_COLLATOR_STAKE: Balance = 200_000;
-
 	/// Reward rate configuration which is used at genesis
 	pub fn reward_rate_config() -> RewardRateInfo {
 		RewardRateInfo::new(Perquintill::from_percent(30), Perquintill::from_percent(70))
@@ -800,6 +798,7 @@ pub mod staking {
 			/// Maximum number of concurrent requests to unlock unstaked balance
 			pub const MaxUnstakeRequests: u32 = 10;
 	}
+	pub const MAX_COLLATOR_STAKE: Balance = 10_000 * MinCollatorStake::get();
 }
 
 impl parachain_staking::Config for Runtime {
@@ -1040,6 +1039,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	parachain_staking::migrations::v7::MigrateToV8<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for Call {

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -765,8 +765,6 @@ impl pallet_session::Config for Runtime {
 pub mod staking {
 	use super::*;
 
-	pub const MAX_COLLATOR_STAKE: Balance = 200_000;
-
 	/// Reward rate configuration which is used at genesis
 	pub fn reward_rate_config() -> RewardRateInfo {
 		RewardRateInfo::new(Perquintill::from_percent(30), Perquintill::from_percent(70))
@@ -803,6 +801,7 @@ pub mod staking {
 			/// Maximum number of concurrent requests to unlock unstaked balance
 			pub const MaxUnstakeRequests: u32 = 10;
 	}
+	pub const MAX_COLLATOR_STAKE: Balance = 10_000 * MinCollatorStake::get();
 }
 
 impl parachain_staking::Config for Runtime {
@@ -1043,6 +1042,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	parachain_staking::migrations::v7::MigrateToV8<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for Call {

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -766,8 +766,6 @@ impl pallet_session::Config for Runtime {
 pub mod staking {
 	use super::*;
 
-	pub const MAX_COLLATOR_STAKE: Balance = 200_000;
-
 	/// Reward rate configuration which is used at genesis
 	pub fn reward_rate_config() -> RewardRateInfo {
 		RewardRateInfo::new(Perquintill::from_percent(30), Perquintill::from_percent(70))
@@ -804,6 +802,7 @@ pub mod staking {
 			/// Maximum number of concurrent requests to unlock unstaked balance
 			pub const MaxUnstakeRequests: u32 = 10;
 	}
+	pub const MAX_COLLATOR_STAKE: Balance = 10_000 * MinCollatorStake::get();
 }
 
 impl parachain_staking::Config for Runtime {
@@ -1058,6 +1057,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	parachain_staking::migrations::v7::MigrateToV8<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for Call {

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -766,8 +766,6 @@ impl pallet_session::Config for Runtime {
 pub mod staking {
 	use super::*;
 
-	pub const MAX_COLLATOR_STAKE: Balance = 200_000;
-
 	/// Reward rate configuration which is used at genesis
 	pub fn reward_rate_config() -> RewardRateInfo {
 		RewardRateInfo::new(Perquintill::from_percent(30), Perquintill::from_percent(70))
@@ -804,6 +802,7 @@ pub mod staking {
 			/// Maximum number of concurrent requests to unlock unstaked balance
 			pub const MaxUnstakeRequests: u32 = 10;
 	}
+	pub const MAX_COLLATOR_STAKE: Balance = 10_000 * MinCollatorStake::get();
 }
 
 impl parachain_staking::Config for Runtime {
@@ -1044,6 +1043,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	parachain_staking::migrations::v7::MigrateToV8<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for Call {


### PR DESCRIPTION
Add the migration because the Krest network's min collator staking is changed, then we have to update the max collator staking in the storage, too.

I use the migration instead of sending the sudo extrinsic to change because we don't need to remember the value by sending the sudo extrinsic.