### PR TITLE
Update multisig pallet the runtime for polkadot.js app

### DIFF
--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -973,7 +973,7 @@ construct_runtime!(
 		// Include the custom pallets
 		PeaqDid: peaq_pallet_did::{Pallet, Call, Storage, Event<T>} = 100,
 		Transaction: peaq_pallet_transaction::{Pallet, Call, Storage, Event<T>} = 101,
-		MultiSig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
+		Multisig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
 		PeaqRbac: peaq_pallet_rbac::{Pallet, Call, Storage, Event<T>} = 103,
 		PeaqStorage: peaq_pallet_storage::{Pallet, Call, Storage, Event<T>} = 104,
 	}
@@ -1026,7 +1026,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_balances, Balances]
 		[pallet_timestamp, Timestamp]
-		[pallet_multisig, MultiSig]
+		[pallet_multisig, Multisig]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[parachain_staking, ParachainStaking]
 		[staking_coefficient_reward, StakingCoefficientRewardCalculator]

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -974,7 +974,7 @@ construct_runtime!(
 		// Include the custom pallets
 		PeaqDid: peaq_pallet_did::{Pallet, Call, Storage, Event<T>} = 100,
 		Transaction: peaq_pallet_transaction::{Pallet, Call, Storage, Event<T>} = 101,
-		MultiSig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
+		Multisig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
 		PeaqRbac: peaq_pallet_rbac::{Pallet, Call, Storage, Event<T>} = 103,
 		PeaqStorage: peaq_pallet_storage::{Pallet, Call, Storage, Event<T>} = 104,
 	}
@@ -1027,7 +1027,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_balances, Balances]
 		[pallet_timestamp, Timestamp]
-		[pallet_multisig, MultiSig]
+		[pallet_multisig, Multisig]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[parachain_staking, ParachainStaking]
 		[staking_coefficient_reward, StakingCoefficientRewardCalculator]

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -992,7 +992,7 @@ construct_runtime!(
 		// Include the custom pallets
 		PeaqDid: peaq_pallet_did::{Pallet, Call, Storage, Event<T>} = 100,
 		Transaction: peaq_pallet_transaction::{Pallet, Call, Storage, Event<T>} = 101,
-		MultiSig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
+		Multisig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
 		PeaqRbac: peaq_pallet_rbac::{Pallet, Call, Storage, Event<T>} = 103,
 		PeaqStorage: peaq_pallet_storage::{Pallet, Call, Storage, Event<T>} = 104,
 		PeaqMor: peaq_pallet_mor::{Pallet, Call, Config<T>, Storage, Event<T>} = 105,
@@ -1046,7 +1046,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_balances, Balances]
 		[pallet_timestamp, Timestamp]
-		[pallet_multisig, MultiSig]
+		[pallet_multisig, Multisig]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[parachain_staking, ParachainStaking]
 		[staking_coefficient_reward, StakingCoefficientRewardCalculator]

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -981,7 +981,7 @@ construct_runtime!(
 		// Include the custom pallets
 		PeaqDid: peaq_pallet_did::{Pallet, Call, Storage, Event<T>} = 100,
 		Transaction: peaq_pallet_transaction::{Pallet, Call, Storage, Event<T>} = 101,
-		MultiSig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
+		Multisig:  pallet_multisig::{Pallet, Call, Storage, Event<T>} = 102,
 		PeaqRbac: peaq_pallet_rbac::{Pallet, Call, Storage, Event<T>} = 103,
 		PeaqStorage: peaq_pallet_storage::{Pallet, Call, Storage, Event<T>} = 104,
 	}
@@ -1034,7 +1034,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_balances, Balances]
 		[pallet_timestamp, Timestamp]
-		[pallet_multisig, MultiSig]
+		[pallet_multisig, Multisig]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[parachain_staking, ParachainStaking]
 		[staking_coefficient_reward, StakingCoefficientRewardCalculator]


### PR DESCRIPTION
We have to rename the MultiSig to Multisig because, in the polkadot.js app, they only recognized the name "Multisg". Otherwise, the multisig page won't show on the account page.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205112789754622