### PR TITLE
Bug/1205335962596950 new pallets init

### DIFF
--- a/pallets/staking-coefficient-reward/src/lib.rs
+++ b/pallets/staking-coefficient-reward/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 pub mod default_weights;
+mod migrations;
 
 #[cfg(test)]
 pub(crate) mod mock;
@@ -15,6 +16,8 @@ pub(crate) mod tests;
 pub use crate::{default_weights::WeightInfo, pallet::*};
 use frame_support::pallet;
 use sp_runtime::traits::{CheckedAdd, CheckedMul};
+
+const DEFAULT_COEFFICIENT: u8 = 8;
 
 #[pallet]
 pub mod pallet {
@@ -64,6 +67,13 @@ pub mod pallet {
 		CoefficientSet(u8),
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migrations::on_runtime_upgrade::<T>()
+		}
+	}
+
 	/// Here, we setup this as u8 because the balance is u128, we might have overflow while
 	// calculating the reward because the fomula is
 	// (collator stake * coefficient) / ( collator stake * coefficient + delegator_sum)
@@ -81,7 +91,7 @@ pub mod pallet {
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
 		fn default() -> Self {
-			Self { coefficient: 8 as u8 }
+			Self { coefficient: DEFAULT_COEFFICIENT }
 		}
 	}
 

--- a/pallets/staking-coefficient-reward/src/migrations.rs
+++ b/pallets/staking-coefficient-reward/src/migrations.rs
@@ -36,7 +36,6 @@ mod upgrade {
 					weight_writes += 1;
 				}
 				weight_reads += 1;
-
 			}
 			T::DbWeight::get().reads_writes(weight_reads, weight_writes)
 		}

--- a/pallets/staking-coefficient-reward/src/migrations.rs
+++ b/pallets/staking-coefficient-reward/src/migrations.rs
@@ -1,7 +1,6 @@
 //! Storage migrations for the parachain-staking  pallet.
 
 use super::*;
-use crate::reward_rate::RewardRateInfo;
 use frame_support::{
 	dispatch::GetStorageVersion,
 	pallet_prelude::{StorageVersion, ValueQuery},
@@ -10,8 +9,7 @@ use frame_support::{
 	weights::Weight,
 };
 
-const CURRENT_STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
-const TARGET_STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
+const CURRENT_STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
 	upgrade::Migrate::<T>::on_runtime_upgrade()
@@ -21,7 +19,7 @@ mod upgrade {
 	use super::*;
 
 	#[storage_alias]
-	type RewardRateConfig<T: Config> = StorageValue<Pallet<T>, RewardRateInfo, ValueQuery>;
+	type CoefficientConfig<T: Config> = StorageValue<Pallet<T>, u8, ValueQuery>;
 
 	/// Migration implementation that renames storage HardCap into MaxCurrencySupply
 	pub struct Migrate<T>(sp_std::marker::PhantomData<T>);
@@ -29,16 +27,16 @@ mod upgrade {
 	impl<T: Config> Migrate<T> {
 		pub fn on_runtime_upgrade() -> Weight {
 			let mut weight_writes = 0;
-			let weight_reads = 0;
+			let mut weight_reads = 0;
 			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();
 			if onchain_storage_version.eq(&CURRENT_STORAGE_VERSION) {
-				TARGET_STORAGE_VERSION.put::<Pallet<T>>();
-				log::error!("Migrating parchain_staking to V8");
+				if !CoefficientConfig::<T>::exists() {
+					log::error!("Update the initial storage");
+					CoefficientConfig::<T>::put(DEFAULT_COEFFICIENT);
+					weight_writes += 1;
+				}
+				weight_reads += 1;
 
-				RewardRateConfig::<T>::kill();
-
-				log::error!("V8 Migrating Done.");
-				weight_writes += 2;
 			}
 			T::DbWeight::get().reads_writes(weight_reads, weight_writes)
 		}

--- a/pallets/staking-fixed-percentage-reward/src/lib.rs
+++ b/pallets/staking-fixed-percentage-reward/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 pub mod default_weights;
+mod migrations;
 
 #[cfg(test)]
 pub(crate) mod mock;
@@ -64,6 +65,13 @@ pub mod pallet {
 		/// Reware rate configuration for future validation rounds has changed.
 		/// \[collator's reward rate,delegator's reward rate\]
 		RoundRewardRateSet(Perquintill, Perquintill),
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migrations::on_runtime_upgrade::<T>()
+		}
 	}
 
 	/// Reward rate configuration.

--- a/pallets/staking-fixed-percentage-reward/src/migrations.rs
+++ b/pallets/staking-fixed-percentage-reward/src/migrations.rs
@@ -1,7 +1,6 @@
 //! Storage migrations for the parachain-staking  pallet.
 
 use super::*;
-use parachain_staking::reward_rate::RewardRateInfo;
 use frame_support::{
 	dispatch::GetStorageVersion,
 	pallet_prelude::{StorageVersion, ValueQuery},
@@ -9,6 +8,7 @@ use frame_support::{
 	traits::Get,
 	weights::Weight,
 };
+use parachain_staking::reward_rate::RewardRateInfo;
 
 const CURRENT_STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 

--- a/pallets/staking-fixed-percentage-reward/src/migrations.rs
+++ b/pallets/staking-fixed-percentage-reward/src/migrations.rs
@@ -37,7 +37,6 @@ mod upgrade {
 					weight_writes += 1;
 				}
 				weight_reads += 1;
-
 			}
 			T::DbWeight::get().reads_writes(weight_reads, weight_writes)
 		}

--- a/pallets/staking-fixed-percentage-reward/src/migrations.rs
+++ b/pallets/staking-fixed-percentage-reward/src/migrations.rs
@@ -1,7 +1,7 @@
 //! Storage migrations for the parachain-staking  pallet.
 
 use super::*;
-use crate::reward_rate::RewardRateInfo;
+use parachain_staking::reward_rate::RewardRateInfo;
 use frame_support::{
 	dispatch::GetStorageVersion,
 	pallet_prelude::{StorageVersion, ValueQuery},

--- a/pallets/staking-fixed-percentage-reward/src/migrations.rs
+++ b/pallets/staking-fixed-percentage-reward/src/migrations.rs
@@ -10,8 +10,7 @@ use frame_support::{
 	weights::Weight,
 };
 
-const CURRENT_STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
-const TARGET_STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
+const CURRENT_STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
 	upgrade::Migrate::<T>::on_runtime_upgrade()
@@ -29,16 +28,16 @@ mod upgrade {
 	impl<T: Config> Migrate<T> {
 		pub fn on_runtime_upgrade() -> Weight {
 			let mut weight_writes = 0;
-			let weight_reads = 0;
+			let mut weight_reads = 0;
 			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();
 			if onchain_storage_version.eq(&CURRENT_STORAGE_VERSION) {
-				TARGET_STORAGE_VERSION.put::<Pallet<T>>();
-				log::error!("Migrating parchain_staking to V8");
+				if !RewardRateConfig::<T>::exists() {
+					log::error!("Update the initial storage");
+					RewardRateConfig::<T>::put(RewardRateInfo::default());
+					weight_writes += 1;
+				}
+				weight_reads += 1;
 
-				RewardRateConfig::<T>::kill();
-
-				log::error!("V8 Migrating Done.");
-				weight_writes += 2;
 			}
 			T::DbWeight::get().reads_writes(weight_reads, weight_writes)
 		}


### PR DESCRIPTION
We have to setup the default parameter; otherwise, it's uninitialized because when we add these pallets during the runtime upgrade, it won't go to the Genesis build.