### PR TITLE
Only change peaq-dev's token/name to Agung related info

### DIFF
--- a/.github/workflows/publishondockerhub.yml
+++ b/.github/workflows/publishondockerhub.yml
@@ -4,22 +4,16 @@ on:
     branches:
       - 'parachain_dev'
     tags:
-      - 'peaq-dev-local-v*' # For the peaq-dev's env in the parchain-launch usage
-      - 'krest-local-v*' # For the krest env in the parchain-launch usage
+      - 'peaq-dev-v*' # For the peaq-dev's env in the parchain-launch usage
+      - 'krest-v*' # For the krest env in the parchain-launch usage
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
-      - name: Diskspace
-        run: |
-          sudo df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo df -h
-      
+      - name: "Free Disk Space (insightsengineering/disk-space-reclaimer)"
+        uses: insightsengineering/disk-space-reclaimer@v1.1.0
+
       - name: Check out the repo
         uses: actions/checkout@v3
 
@@ -38,6 +32,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -56,7 +56,7 @@ pub fn get_chain_spec_local_testnet(para_id: u32) -> Result<ChainSpec, String> {
 	properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
 
 	Ok(ChainSpec::from_genesis(
-		"Agung-network",
+		"Agung-parachain",
 		"dev-testnet",
 		ChainType::Development,
 		move || {

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -52,11 +52,11 @@ pub fn get_chain_spec_local_testnet(para_id: u32) -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
 	let mut properties = Properties::new();
-	properties.insert("tokenSymbol".into(), "PEAQ".into());
+	properties.insert("tokenSymbol".into(), "AGUNG".into());
 	properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
 
 	Ok(ChainSpec::from_genesis(
-		"peaq-dev",
+		"Agung-network",
 		"dev-testnet",
 		ChainType::Development,
 		move || {


### PR DESCRIPTION
This is the first change for clarifying the peaq-dev parachain and agung parachain. Therefore, we changed the name of the peaq-dev to the agung network; however, in the runtime module, we are still using the peaq-dev but not agung runtime module