### PR TITLE
Some fixes to peaq bc test workflow

### DIFF
--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -28,7 +28,14 @@ jobs:
                 pip install -r requirements.txt
 
             # Use github secrets to pass autotest URI as env variable to run tests
+            # This suite ignores tests that utilize parachain_launch methods or XCM channels as neither are available in Autotest env.
             - name: Run peaq-bc-test
               run: |
                 cd peaq-bc-test
-                AUTOTEST_URI="${{ secrets.AUTOTEST_HOST }}" pytest -v --ignore=tests/zenlink_dex_test.py --ignore=tests/xcm_transfer_test.py
+                AUTOTEST_URI="${{ secrets.AUTOTEST_HOST }}" pytest -v \
+                --ignore=tests/zenlink_dex_test.py \
+                --ignore=tests/xcm_transfer_test.py \
+                --ignore=tests/bridge_xtokens_test.py \
+                --ignore=tests/delegator_issue_test.py \
+                --ignore=test/reward_distribution_test.py \
+                --ignore=test/token_economy_test.py           

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -39,4 +39,4 @@ jobs:
                 --ignore=tests/delegator_issue_test.py \
                 --ignore=test/reward_distribution_test.py \
                 --ignore=test/token_economy_test.py \
-                --ignore=test/bride_xcmutils_test.py       
+                --ignore=test/bridge_xcmutils_test.py       

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -39,4 +39,9 @@ jobs:
                 --ignore=tests/delegator_issue_test.py \
                 --ignore=tests/reward_distribution_test.py \
                 --ignore=tests/token_economy_test.py \
-                --ignore=tests/bridge_xcmutils_test.py       
+                --ignore=tests/bridge_xcmutils_test.py
+    # We redeploy the autotest env as to clear the state of the parachain
+    redeploy:
+        runs-on: ubuntu-20.04
+        steps:
+          - uses: ./workflows/ManualPublish_and_Deployment.yml/trigger-deploy

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -1,47 +1,47 @@
 name: Peaq BC Test
 # This workflow is triggered on dev branch manually or automatically after the Build and Publish workflow is completed
 on:
-    workflow_dispatch:
-    workflow_run:
-      workflows: [Build and Publish]
-      types: [completed]
-      branches: [dev]
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Build and Publish]
+    types: [completed]
+    branches: [dev]
 
 jobs:
-    bc-test:
-        # NOTE: Python3 comes preinstalled in ubuntu, so no need to install it
-        runs-on: ubuntu-20.04
+  bc-test:
+    # NOTE: Python3 comes preinstalled in ubuntu, so no need to install it
+    runs-on: ubuntu-20.04
 
-        steps:
-            - name: Clone peaq-bc-repo
-              uses: GuillaumeFalourd/clone-github-repo-action@v2.3
-              with:
-                depth: 1
-                branch: main
-                owner: peaqnetwork
-                repository: peaq-bc-test
+    steps:
+      - name: Clone peaq-bc-repo
+        uses: GuillaumeFalourd/clone-github-repo-action@v2.3
+        with:
+          depth: 1
+          branch: main
+          owner: peaqnetwork
+          repository: peaq-bc-test
 
-            - name: Install dependencies for peaq-bc-test
-              run: |
-                cd peaq-bc-test
-                python3 -m pip install --upgrade pip
-                pip install -r requirements.txt
+      - name: Install dependencies for peaq-bc-test
+        run: |
+          cd peaq-bc-test
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-            # Use github secrets to pass autotest URI as env variable to run tests
-            # This suite ignores tests that utilize parachain_launch methods or XCM channels as neither are available in Autotest env.
-            - name: Run peaq-bc-test
-              run: |
-                cd peaq-bc-test
-                AUTOTEST_URI="${{ secrets.AUTOTEST_HOST }}" pytest -v \
-                --ignore=tests/zenlink_dex_test.py \
-                --ignore=tests/xcm_transfer_test.py \
-                --ignore=tests/bridge_xtokens_test.py \
-                --ignore=tests/delegator_issue_test.py \
-                --ignore=tests/reward_distribution_test.py \
-                --ignore=tests/token_economy_test.py \
-                --ignore=tests/bridge_xcmutils_test.py
-    # We redeploy the autotest env as to clear the state of the parachain
-    redeploy:
-        runs-on: ubuntu-20.04
-        steps:
-          - uses: ./workflows/ManualPublish_and_Deployment.yml/trigger-deploy
+      # Use github secrets to pass autotest URI as env variable to run tests
+      # This suite ignores tests that utilize parachain_launch methods or XCM channels as neither are available in Autotest env.
+      - name: Run peaq-bc-test
+        run: |
+          cd peaq-bc-test
+          AUTOTEST_URI="${{ secrets.AUTOTEST_HOST }}" pytest -v \
+          --ignore=tests/zenlink_dex_test.py \
+          --ignore=tests/xcm_transfer_test.py \
+          --ignore=tests/bridge_xtokens_test.py \
+          --ignore=tests/delegator_issue_test.py \
+          --ignore=tests/reward_distribution_test.py \
+          --ignore=tests/token_economy_test.py \
+          --ignore=tests/bridge_xcmutils_test.py
+  # We redeploy the autotest env as to clear the state of the parachain
+  redeploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: ./workflows/ManualPublish_and_Deployment.yml/trigger-deploy

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -40,6 +40,7 @@ jobs:
           --ignore=tests/reward_distribution_test.py \
           --ignore=tests/token_economy_test.py \
           --ignore=tests/bridge_xcmutils_test.py
+          
   # We redeploy the autotest env as to clear the state of the parachain
   redeploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -37,6 +37,6 @@ jobs:
                 --ignore=tests/xcm_transfer_test.py \
                 --ignore=tests/bridge_xtokens_test.py \
                 --ignore=tests/delegator_issue_test.py \
-                --ignore=test/reward_distribution_test.py \
-                --ignore=test/token_economy_test.py \
-                --ignore=test/bridge_xcmutils_test.py       
+                --ignore=tests/reward_distribution_test.py \
+                --ignore=tests/token_economy_test.py \
+                --ignore=tests/bridge_xcmutils_test.py       

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -40,9 +40,9 @@ jobs:
           --ignore=tests/reward_distribution_test.py \
           --ignore=tests/token_economy_test.py \
           --ignore=tests/bridge_xcmutils_test.py
-          
+
   # We redeploy the autotest env as to clear the state of the parachain
-  redeploy:
+  deploy:
     runs-on: ubuntu-20.04
     steps:
       - uses: ./workflows/ManualPublish_and_Deployment.yml/trigger-deploy

--- a/.github/workflows/bc-test-deployment.yml
+++ b/.github/workflows/bc-test-deployment.yml
@@ -38,4 +38,5 @@ jobs:
                 --ignore=tests/bridge_xtokens_test.py \
                 --ignore=tests/delegator_issue_test.py \
                 --ignore=test/reward_distribution_test.py \
-                --ignore=test/token_economy_test.py           
+                --ignore=test/token_economy_test.py \
+                --ignore=test/bride_xcmutils_test.py       


### PR DESCRIPTION
This MR is a WIP, opened for discussion.

Aims to do the following
* Ignore tests that utilise parachain_launch methods or XCM channels, as neither are available to autotest env.
* Reset autotest state before and after Peaq BC Test workflow is run, to keep the chain state exclusive to this workflow, avoiding interfering with QA's work.
* Fixing the issue where workflow hangs on the 'run peaq-bc-test' step.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206829001769402