### PR TITLE
Block reward split change

### DIFF
--- a/node/src/parachain/agung_chain_spec.rs
+++ b/node/src/parachain/agung_chain_spec.rs
@@ -129,6 +129,8 @@ fn configure_genesis(
 				lp_percent: Perbill::from_percent(25),
 				machines_percent: Perbill::from_percent(10),
 				parachain_lease_fund_percent: Perbill::from_percent(10),
+				depin_staking_percent: Perbill::from_percent(0),
+				depin_incentivization_percent: Perbill::from_percent(0),
 			},
 			block_issue_reward: 7_909_867 * MILLICENTS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/node/src/parachain/agung_chain_spec.rs
+++ b/node/src/parachain/agung_chain_spec.rs
@@ -124,10 +124,10 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(20),
-				dapps_percent: Perbill::from_percent(25),
-				collators_percent: Perbill::from_percent(10),
-				lp_percent: Perbill::from_percent(25),
-				machines_percent: Perbill::from_percent(10),
+				depin_percent: Perbill::from_percent(25),
+				collators_delegators_percent: Perbill::from_percent(10),
+				coretime_percent: Perbill::from_percent(25),
+				subsidization_pool_percent: Perbill::from_percent(10),
 				parachain_lease_fund_percent: Perbill::from_percent(10),
 				depin_staking_percent: Perbill::from_percent(0),
 				depin_incentivization_percent: Perbill::from_percent(0),

--- a/node/src/parachain/agung_chain_spec.rs
+++ b/node/src/parachain/agung_chain_spec.rs
@@ -124,11 +124,9 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				depin_percent: Perbill::from_percent(0),
 				collators_delegators_percent: Perbill::from_percent(40),
 				coretime_percent: Perbill::from_percent(10),
 				subsidization_pool_percent: Perbill::from_percent(5),
-				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),
 			},

--- a/node/src/parachain/agung_chain_spec.rs
+++ b/node/src/parachain/agung_chain_spec.rs
@@ -123,14 +123,14 @@ fn configure_genesis(
 		block_reward: BlockRewardConfig {
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
-				treasury_percent: Perbill::from_percent(20),
-				depin_percent: Perbill::from_percent(25),
-				collators_delegators_percent: Perbill::from_percent(10),
-				coretime_percent: Perbill::from_percent(25),
-				subsidization_pool_percent: Perbill::from_percent(10),
-				parachain_lease_fund_percent: Perbill::from_percent(10),
-				depin_staking_percent: Perbill::from_percent(0),
-				depin_incentivization_percent: Perbill::from_percent(0),
+				treasury_percent: Perbill::from_percent(25),
+				depin_percent: Perbill::from_percent(0),
+				collators_delegators_percent: Perbill::from_percent(40),
+				coretime_percent: Perbill::from_percent(10),
+				subsidization_pool_percent: Perbill::from_percent(5),
+				parachain_lease_fund_percent: Perbill::from_percent(0),
+				depin_staking_percent: Perbill::from_percent(5),
+				depin_incentivization_percent: Perbill::from_percent(15),
 			},
 			block_issue_reward: 7_909_867 * MILLICENTS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -143,12 +143,12 @@ fn configure_genesis(
 		block_reward: BlockRewardConfig {
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
-				treasury_percent: Perbill::from_percent(20),
-				dapps_percent: Perbill::from_percent(25),
-				collators_percent: Perbill::from_percent(10),
-				lp_percent: Perbill::from_percent(25),
-				machines_percent: Perbill::from_percent(10),
-				parachain_lease_fund_percent: Perbill::from_percent(10),
+				treasury_percent: Perbill::from_percent(25),
+				dapps_percent: Perbill::from_percent(20),
+				collators_percent: Perbill::from_percent(40),
+				lp_percent: Perbill::from_percent(10),
+				machines_percent: Perbill::from_percent(5),
+				parachain_lease_fund_percent: Perbill::from_percent(0),
 			},
 			block_issue_reward: DOLLARS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -144,11 +144,13 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(20),
+				dapps_percent: Perbill::from_percent(0),
 				collators_percent: Perbill::from_percent(40),
 				lp_percent: Perbill::from_percent(10),
 				machines_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
+				depin_staking_percent: Perbill::from_percent(5),
+				depin_incentivization_percent: Perbill::from_percent(15),
 			},
 			block_issue_reward: DOLLARS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -144,11 +144,9 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				depin_percent: Perbill::from_percent(0),
 				collators_delegators_percent: Perbill::from_percent(40),
 				coretime_percent: Perbill::from_percent(10),
 				subsidization_pool_percent: Perbill::from_percent(5),
-				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),
 			},

--- a/node/src/parachain/dev_chain_spec.rs
+++ b/node/src/parachain/dev_chain_spec.rs
@@ -144,10 +144,10 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(0),
-				collators_percent: Perbill::from_percent(40),
-				lp_percent: Perbill::from_percent(10),
-				machines_percent: Perbill::from_percent(5),
+				depin_percent: Perbill::from_percent(0),
+				collators_delegators_percent: Perbill::from_percent(40),
+				coretime_percent: Perbill::from_percent(10),
+				subsidization_pool_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),

--- a/node/src/parachain/krest_chain_spec.rs
+++ b/node/src/parachain/krest_chain_spec.rs
@@ -128,11 +128,13 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(20),
+				dapps_percent: Perbill::from_percent(0),
 				collators_percent: Perbill::from_percent(40),
 				lp_percent: Perbill::from_percent(10),
 				machines_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
+				depin_staking_percent: Perbill::from_percent(5),
+				depin_incentivization_percent: Perbill::from_percent(15),
 			},
 			block_issue_reward: 380_517_503_805 * NANOCENTS,
 			max_currency_supply: 400_000_000 * DOLLARS,

--- a/node/src/parachain/krest_chain_spec.rs
+++ b/node/src/parachain/krest_chain_spec.rs
@@ -128,10 +128,10 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(0),
-				collators_percent: Perbill::from_percent(40),
-				lp_percent: Perbill::from_percent(10),
-				machines_percent: Perbill::from_percent(5),
+				depin_percent: Perbill::from_percent(0),
+				collators_delegators_percent: Perbill::from_percent(40),
+				coretime_percent: Perbill::from_percent(10),
+				subsidization_pool_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),

--- a/node/src/parachain/krest_chain_spec.rs
+++ b/node/src/parachain/krest_chain_spec.rs
@@ -128,11 +128,9 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				depin_percent: Perbill::from_percent(0),
 				collators_delegators_percent: Perbill::from_percent(40),
 				coretime_percent: Perbill::from_percent(10),
 				subsidization_pool_percent: Perbill::from_percent(5),
-				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),
 			},

--- a/node/src/parachain/krest_chain_spec.rs
+++ b/node/src/parachain/krest_chain_spec.rs
@@ -127,12 +127,12 @@ fn configure_genesis(
 		block_reward: BlockRewardConfig {
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
-				treasury_percent: Perbill::from_percent(15),
-				dapps_percent: Perbill::from_percent(15),
-				collators_percent: Perbill::from_percent(30),
-				lp_percent: Perbill::from_percent(15),
-				machines_percent: Perbill::from_percent(15),
-				parachain_lease_fund_percent: Perbill::from_percent(10),
+				treasury_percent: Perbill::from_percent(25),
+				dapps_percent: Perbill::from_percent(20),
+				collators_percent: Perbill::from_percent(40),
+				lp_percent: Perbill::from_percent(10),
+				machines_percent: Perbill::from_percent(5),
+				parachain_lease_fund_percent: Perbill::from_percent(0),
 			},
 			block_issue_reward: 380_517_503_805 * NANOCENTS,
 			max_currency_supply: 400_000_000 * DOLLARS,

--- a/node/src/parachain/peaq_chain_spec.rs
+++ b/node/src/parachain/peaq_chain_spec.rs
@@ -133,11 +133,13 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(20),
+				dapps_percent: Perbill::from_percent(0),
 				collators_percent: Perbill::from_percent(40),
 				lp_percent: Perbill::from_percent(10),
 				machines_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
+				depin_staking_percent: Perbill::from_percent(5),
+				depin_incentivization_percent: Perbill::from_percent(15),
 			},
 			block_issue_reward: 7_909_867 * MILLICENTS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/node/src/parachain/peaq_chain_spec.rs
+++ b/node/src/parachain/peaq_chain_spec.rs
@@ -133,10 +133,10 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				dapps_percent: Perbill::from_percent(0),
-				collators_percent: Perbill::from_percent(40),
-				lp_percent: Perbill::from_percent(10),
-				machines_percent: Perbill::from_percent(5),
+				depin_percent: Perbill::from_percent(0),
+				collators_delegators_percent: Perbill::from_percent(40),
+				coretime_percent: Perbill::from_percent(10),
+				subsidization_pool_percent: Perbill::from_percent(5),
 				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),

--- a/node/src/parachain/peaq_chain_spec.rs
+++ b/node/src/parachain/peaq_chain_spec.rs
@@ -133,11 +133,9 @@ fn configure_genesis(
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
 				treasury_percent: Perbill::from_percent(25),
-				depin_percent: Perbill::from_percent(0),
 				collators_delegators_percent: Perbill::from_percent(40),
 				coretime_percent: Perbill::from_percent(10),
 				subsidization_pool_percent: Perbill::from_percent(5),
-				parachain_lease_fund_percent: Perbill::from_percent(0),
 				depin_staking_percent: Perbill::from_percent(5),
 				depin_incentivization_percent: Perbill::from_percent(15),
 			},

--- a/node/src/parachain/peaq_chain_spec.rs
+++ b/node/src/parachain/peaq_chain_spec.rs
@@ -132,12 +132,12 @@ fn configure_genesis(
 		block_reward: BlockRewardConfig {
 			// Make sure sum is 100
 			reward_config: pallet_block_reward::RewardDistributionConfig {
-				treasury_percent: Perbill::from_percent(20),
-				dapps_percent: Perbill::from_percent(25),
-				collators_percent: Perbill::from_percent(10),
-				lp_percent: Perbill::from_percent(25),
-				machines_percent: Perbill::from_percent(10),
-				parachain_lease_fund_percent: Perbill::from_percent(10),
+				treasury_percent: Perbill::from_percent(25),
+				dapps_percent: Perbill::from_percent(20),
+				collators_percent: Perbill::from_percent(40),
+				lp_percent: Perbill::from_percent(10),
+				machines_percent: Perbill::from_percent(5),
+				parachain_lease_fund_percent: Perbill::from_percent(0),
 			},
 			block_issue_reward: 7_909_867 * MILLICENTS,
 			max_currency_supply: 4_200_000_000 * DOLLARS,

--- a/pallets/block-reward/src/lib.rs
+++ b/pallets/block-reward/src/lib.rs
@@ -285,12 +285,16 @@ pub mod pallet {
 			let machines_balance = distro_params.machines_percent * imbalance.peek();
 			let parachain_lease_fund_balance =
 				distro_params.parachain_lease_fund_percent * imbalance.peek();
+			let depin_staking_balance = distro_params.depin_staking_percent * imbalance.peek();
+			let depin_incentivization_balance = distro_params.depin_incentivization_percent * imbalance.peek();
 
 			// Prepare imbalances
 			let (dapps_imbalance, remainder) = imbalance.split(dapps_balance);
 			let (collator_imbalance, remainder) = remainder.split(collator_balance);
 			let (lp_imbalance, remainder) = remainder.split(lp_balance);
 			let (machines_imbalance, remainder) = remainder.split(machines_balance);
+			let (depin_staking_imbalance, remainder) = remainder.split(depin_staking_balance);
+			let (depin_incentivization_imbalance, remainder) = remainder.split(depin_incentivization_balance);
 			let (parachain_lease_fund_balance, treasury_imbalance) =
 				remainder.split(parachain_lease_fund_balance);
 
@@ -301,6 +305,8 @@ pub mod pallet {
 			T::BeneficiaryPayout::lp_users(lp_imbalance);
 			T::BeneficiaryPayout::machines(machines_imbalance);
 			T::BeneficiaryPayout::parachain_lease_fund(parachain_lease_fund_balance);
+			T::BeneficiaryPayout::depin_staking(depin_staking_imbalance);
+			T::BeneficiaryPayout::depin_incentivization(depin_incentivization_imbalance);
 
 			Self::deposit_event(dpt_event);
 		}

--- a/pallets/block-reward/src/lib.rs
+++ b/pallets/block-reward/src/lib.rs
@@ -286,7 +286,8 @@ pub mod pallet {
 			let parachain_lease_fund_balance =
 				distro_params.parachain_lease_fund_percent * imbalance.peek();
 			let depin_staking_balance = distro_params.depin_staking_percent * imbalance.peek();
-			let depin_incentivization_balance = distro_params.depin_incentivization_percent * imbalance.peek();
+			let depin_incentivization_balance =
+				distro_params.depin_incentivization_percent * imbalance.peek();
 
 			// Prepare imbalances
 			let (dapps_imbalance, remainder) = imbalance.split(dapps_balance);
@@ -294,7 +295,8 @@ pub mod pallet {
 			let (lp_imbalance, remainder) = remainder.split(lp_balance);
 			let (machines_imbalance, remainder) = remainder.split(machines_balance);
 			let (depin_staking_imbalance, remainder) = remainder.split(depin_staking_balance);
-			let (depin_incentivization_imbalance, remainder) = remainder.split(depin_incentivization_balance);
+			let (depin_incentivization_imbalance, remainder) =
+				remainder.split(depin_incentivization_balance);
 			let (parachain_lease_fund_balance, treasury_imbalance) =
 				remainder.split(parachain_lease_fund_balance);
 

--- a/pallets/block-reward/src/lib.rs
+++ b/pallets/block-reward/src/lib.rs
@@ -279,38 +279,30 @@ pub mod pallet {
 			let distro_params = Self::reward_config();
 
 			// Pre-calculate balance which will be deposited for each beneficiary
-			let depin_balance = distro_params.depin_percent * imbalance.peek();
 			let collator_delegator_balance =
 				distro_params.collators_delegators_percent * imbalance.peek();
 			let coretime_balance = distro_params.coretime_percent * imbalance.peek();
 			let subsidization_pool_balance =
 				distro_params.subsidization_pool_percent * imbalance.peek();
-			let parachain_lease_fund_balance =
-				distro_params.parachain_lease_fund_percent * imbalance.peek();
 			let depin_staking_balance = distro_params.depin_staking_percent * imbalance.peek();
 			let depin_incentivization_balance =
 				distro_params.depin_incentivization_percent * imbalance.peek();
 
 			// Prepare imbalances
-			let (depin_imbalance, remainder) = imbalance.split(depin_balance);
 			let (collator_delegator_imbalance, remainder) =
-				remainder.split(collator_delegator_balance);
+				imbalance.split(collator_delegator_balance);
 			let (coretime_imbalance, remainder) = remainder.split(coretime_balance);
 			let (subsidization_pool_imbalance, remainder) =
 				remainder.split(subsidization_pool_balance);
 			let (depin_staking_imbalance, remainder) = remainder.split(depin_staking_balance);
-			let (depin_incentivization_imbalance, remainder) =
+			let (depin_incentivization_imbalance, treasury_imbalance) =
 				remainder.split(depin_incentivization_balance);
-			let (parachain_lease_fund_balance, treasury_imbalance) =
-				remainder.split(parachain_lease_fund_balance);
 
 			// Payout beneficiaries
 			T::BeneficiaryPayout::treasury(treasury_imbalance);
 			T::BeneficiaryPayout::collators_delegators(collator_delegator_imbalance);
-			T::BeneficiaryPayout::depin(depin_imbalance);
 			T::BeneficiaryPayout::coretime(coretime_imbalance);
 			T::BeneficiaryPayout::subsidization_pool(subsidization_pool_imbalance);
-			T::BeneficiaryPayout::parachain_lease_fund(parachain_lease_fund_balance);
 			T::BeneficiaryPayout::depin_staking(depin_staking_imbalance);
 			T::BeneficiaryPayout::depin_incentivization(depin_incentivization_imbalance);
 

--- a/pallets/block-reward/src/lib.rs
+++ b/pallets/block-reward/src/lib.rs
@@ -77,7 +77,7 @@ pub mod pallet {
 
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -279,10 +279,12 @@ pub mod pallet {
 			let distro_params = Self::reward_config();
 
 			// Pre-calculate balance which will be deposited for each beneficiary
-			let dapps_balance = distro_params.depin_percent * imbalance.peek();
-			let collator_balance = distro_params.collators_delegators_percent * imbalance.peek();
-			let lp_balance = distro_params.coretime_percent * imbalance.peek();
-			let machines_balance = distro_params.subsidization_pool_percent * imbalance.peek();
+			let depin_balance = distro_params.depin_percent * imbalance.peek();
+			let collator_delegator_balance =
+				distro_params.collators_delegators_percent * imbalance.peek();
+			let coretime_balance = distro_params.coretime_percent * imbalance.peek();
+			let subsidization_pool_balance =
+				distro_params.subsidization_pool_percent * imbalance.peek();
 			let parachain_lease_fund_balance =
 				distro_params.parachain_lease_fund_percent * imbalance.peek();
 			let depin_staking_balance = distro_params.depin_staking_percent * imbalance.peek();
@@ -290,10 +292,12 @@ pub mod pallet {
 				distro_params.depin_incentivization_percent * imbalance.peek();
 
 			// Prepare imbalances
-			let (dapps_imbalance, remainder) = imbalance.split(dapps_balance);
-			let (collator_imbalance, remainder) = remainder.split(collator_balance);
-			let (lp_imbalance, remainder) = remainder.split(lp_balance);
-			let (machines_imbalance, remainder) = remainder.split(machines_balance);
+			let (depin_imbalance, remainder) = imbalance.split(depin_balance);
+			let (collator_delegator_imbalance, remainder) =
+				remainder.split(collator_delegator_balance);
+			let (coretime_imbalance, remainder) = remainder.split(coretime_balance);
+			let (subsidization_pool_imbalance, remainder) =
+				remainder.split(subsidization_pool_balance);
 			let (depin_staking_imbalance, remainder) = remainder.split(depin_staking_balance);
 			let (depin_incentivization_imbalance, remainder) =
 				remainder.split(depin_incentivization_balance);
@@ -302,10 +306,10 @@ pub mod pallet {
 
 			// Payout beneficiaries
 			T::BeneficiaryPayout::treasury(treasury_imbalance);
-			T::BeneficiaryPayout::collators(collator_imbalance);
-			T::BeneficiaryPayout::dapps_staking(dapps_imbalance);
-			T::BeneficiaryPayout::lp_users(lp_imbalance);
-			T::BeneficiaryPayout::machines(machines_imbalance);
+			T::BeneficiaryPayout::collators_delegators(collator_delegator_imbalance);
+			T::BeneficiaryPayout::depin(depin_imbalance);
+			T::BeneficiaryPayout::coretime(coretime_imbalance);
+			T::BeneficiaryPayout::subsidization_pool(subsidization_pool_imbalance);
 			T::BeneficiaryPayout::parachain_lease_fund(parachain_lease_fund_balance);
 			T::BeneficiaryPayout::depin_staking(depin_staking_imbalance);
 			T::BeneficiaryPayout::depin_incentivization(depin_incentivization_imbalance);

--- a/pallets/block-reward/src/lib.rs
+++ b/pallets/block-reward/src/lib.rs
@@ -279,10 +279,10 @@ pub mod pallet {
 			let distro_params = Self::reward_config();
 
 			// Pre-calculate balance which will be deposited for each beneficiary
-			let dapps_balance = distro_params.dapps_percent * imbalance.peek();
-			let collator_balance = distro_params.collators_percent * imbalance.peek();
-			let lp_balance = distro_params.lp_percent * imbalance.peek();
-			let machines_balance = distro_params.machines_percent * imbalance.peek();
+			let dapps_balance = distro_params.depin_percent * imbalance.peek();
+			let collator_balance = distro_params.collators_delegators_percent * imbalance.peek();
+			let lp_balance = distro_params.coretime_percent * imbalance.peek();
+			let machines_balance = distro_params.subsidization_pool_percent * imbalance.peek();
 			let parachain_lease_fund_balance =
 				distro_params.parachain_lease_fund_percent * imbalance.peek();
 			let depin_staking_balance = distro_params.depin_staking_percent * imbalance.peek();

--- a/pallets/block-reward/src/migrations.rs
+++ b/pallets/block-reward/src/migrations.rs
@@ -68,8 +68,6 @@ mod v2 {
 						collators_delegators_percent: Perbill::from_percent(40),
 						coretime_percent: Perbill::from_percent(10),
 						subsidization_pool_percent: Perbill::from_percent(5),
-						parachain_lease_fund_percent: Perbill::from_percent(0),
-						depin_percent: Perbill::from_percent(0),
 					};
 					RewardDistributionConfigStorage::<T>::put(new_config);
 					log!(info, "Releases::V2_3_0 Migrating Done.");

--- a/pallets/block-reward/src/migrations.rs
+++ b/pallets/block-reward/src/migrations.rs
@@ -65,11 +65,11 @@ mod v2 {
 						treasury_percent: Perbill::from_percent(25),
 						depin_staking_percent: Perbill::from_percent(5),
 						depin_incentivization_percent: Perbill::from_percent(15),
-						collators_percent: Perbill::from_percent(40),
-						lp_percent: Perbill::from_percent(10),
-						machines_percent: Perbill::from_percent(5),
+						collators_delegators_percent: Perbill::from_percent(40),
+						coretime_percent: Perbill::from_percent(10),
+						subsidization_pool_percent: Perbill::from_percent(5),
 						parachain_lease_fund_percent: Perbill::from_percent(0),
-						dapps_percent: Perbill::from_percent(0),
+						depin_percent: Perbill::from_percent(0),
 					};
 					RewardDistributionConfigStorage::<T>::put(new_config);
 					log!(info, "Releases::V2_3_0 Migrating Done.");

--- a/pallets/block-reward/src/migrations.rs
+++ b/pallets/block-reward/src/migrations.rs
@@ -13,8 +13,8 @@ use sp_runtime::traits::Zero;
 pub enum ObsoleteStorageReleases {
 	V2_0_0,
 	V2_1_0, // First changes compared to releases before, renaming HardCap to MaxCurrencySupply
-	#[default]
 	V2_2_0, // change the machine subsidization to parachain lease fund
+	#[default]
 	V2_3_0, // change the reward distribution configuration
 }
 

--- a/pallets/block-reward/src/migrations.rs
+++ b/pallets/block-reward/src/migrations.rs
@@ -15,6 +15,7 @@ pub enum ObsoleteStorageReleases {
 	V2_1_0, // First changes compared to releases before, renaming HardCap to MaxCurrencySupply
 	#[default]
 	V2_2_0, // change the machine subsidization to parachain lease fund
+	V2_3_0, // change the reward distribution configuration
 }
 
 pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
@@ -23,6 +24,7 @@ pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
 
 mod v2 {
 	use super::*;
+	use sp_runtime::Perbill;
 
 	#[storage_alias]
 	type VersionStorage<T: Config> = StorageValue<Pallet<T>, ObsoleteStorageReleases, ValueQuery>;
@@ -55,6 +57,24 @@ mod v2 {
 					log!(info, "Releases::V2_1_0 Migrating Done.");
 					weight_reads += 1;
 					weight_writes += 2
+				}
+				log!(info, "Enter and do the migration, {:?} < {:?}", onchain_version, current);
+				if RewardDistributionConfigStorage::<T>::exists() {
+					log!(info, "Migrating block_reward to Releases::V2_3_0");
+					let new_config = RewardDistributionConfig {
+						treasury_percent: Perbill::from_percent(25),
+						depin_staking_percent: Perbill::from_percent(5),
+						depin_incentivization_percent: Perbill::from_percent(15),
+						collators_percent: Perbill::from_percent(40),
+						lp_percent: Perbill::from_percent(10),
+						machines_percent: Perbill::from_percent(5),
+						parachain_lease_fund_percent: Perbill::from_percent(0),
+						dapps_percent: Perbill::from_percent(0),
+					};
+					RewardDistributionConfigStorage::<T>::put(new_config);
+					log!(info, "Releases::V2_3_0 Migrating Done.");
+					weight_reads += 1;
+					weight_writes += 1;
 				}
 				// Ignore the RewardDistributionConfigStorageV0 directly because it will
 				// automatically chain

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -151,7 +151,10 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalanceOf<TestRuntime>>
 	}
 
 	fn depin_incentivization(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&DE_PININCENTIVIZATION_ACCOUNT.into_account_truncating(), reward);
+		Balances::resolve_creating(
+			&DE_PININCENTIVIZATION_ACCOUNT.into_account_truncating(),
+			reward,
+		);
 	}
 }
 

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -126,19 +126,19 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalanceOf<TestRuntime>>
 		Balances::resolve_creating(&TREASURY_POT.into_account_truncating(), reward);
 	}
 
-	fn collators(reward: NegativeImbalanceOf<TestRuntime>) {
+	fn collators_delegators(reward: NegativeImbalanceOf<TestRuntime>) {
 		Balances::resolve_creating(&COLLATOR_POT.into_account_truncating(), reward);
 	}
 
-	fn dapps_staking(reward: NegativeImbalanceOf<TestRuntime>) {
+	fn depin(reward: NegativeImbalanceOf<TestRuntime>) {
 		Balances::resolve_creating(&DAPPS_POT.into_account_truncating(), reward);
 	}
 
-	fn lp_users(reward: NegativeImbalanceOf<TestRuntime>) {
+	fn coretime(reward: NegativeImbalanceOf<TestRuntime>) {
 		Balances::resolve_creating(&LP_POT.into_account_truncating(), reward);
 	}
 
-	fn machines(reward: NegativeImbalanceOf<TestRuntime>) {
+	fn subsidization_pool(reward: NegativeImbalanceOf<TestRuntime>) {
 		Balances::resolve_creating(&MACHINE_POT.into_account_truncating(), reward);
 	}
 

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -114,6 +114,8 @@ pub(crate) const DAPPS_POT: PalletId = PalletId(*b"mokdapps");
 pub(crate) const LP_POT: PalletId = PalletId(*b"lpreward");
 pub(crate) const MACHINE_POT: PalletId = PalletId(*b"machiner");
 pub(crate) const PARACHAIN_LEASE_FUND: PalletId = PalletId(*b"parlease");
+pub(crate) const DE_PINSTAKING_ACCOUNT: PalletId = PalletId(*b"depinstk");
+pub(crate) const DE_PININCENTIVIZATION_ACCOUNT: PalletId = PalletId(*b"depininc");
 
 // Type used as beneficiary payout handle
 pub struct BeneficiaryPayout();
@@ -142,6 +144,14 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalanceOf<TestRuntime>>
 
 	fn parachain_lease_fund(reward: NegativeImbalanceOf<TestRuntime>) {
 		Balances::resolve_creating(&PARACHAIN_LEASE_FUND.into_account_truncating(), reward);
+	}
+
+	fn depin_staking(reward: NegativeImbalanceOf<TestRuntime>) {
+		Balances::resolve_creating(&DE_PINSTAKING_ACCOUNT.into_account_truncating(), reward);
+	}
+
+	fn depin_incentivization(reward: NegativeImbalanceOf<TestRuntime>) {
+		Balances::resolve_creating(&DE_PININCENTIVIZATION_ACCOUNT.into_account_truncating(), reward);
 	}
 }
 

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -112,8 +112,8 @@ pub(crate) const TREASURY_POT: PalletId = PalletId(*b"moktrsry");
 pub(crate) const COLLATOR_DELEGATOR_POT: PalletId = PalletId(*b"mokcolat");
 pub(crate) const CORETIME_POT: PalletId = PalletId(*b"lpreward");
 pub(crate) const SUBSIDIZATION_POT: PalletId = PalletId(*b"machiner");
-pub(crate) const DE_PINSTAKING_ACCOUNT: PalletId = PalletId(*b"depinstk");
-pub(crate) const DE_PININCENTIVIZATION_ACCOUNT: PalletId = PalletId(*b"depininc");
+pub(crate) const DE_PINSTAKING_ACCOUNT: PalletId = PalletId(*b"destakin");
+pub(crate) const DE_PININCENTIVIZATION_ACCOUNT: PalletId = PalletId(*b"deincent");
 
 // Type used as beneficiary payout handle
 pub struct BeneficiaryPayout();

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -109,11 +109,9 @@ pub(crate) const MAX_CURRENCY_SUPPLY: Balance = 900_000_000;
 
 // Fake accounts used to simulate reward beneficiaries balances
 pub(crate) const TREASURY_POT: PalletId = PalletId(*b"moktrsry");
-pub(crate) const COLLATOR_POT: PalletId = PalletId(*b"mokcolat");
-pub(crate) const DAPPS_POT: PalletId = PalletId(*b"mokdapps");
-pub(crate) const LP_POT: PalletId = PalletId(*b"lpreward");
-pub(crate) const MACHINE_POT: PalletId = PalletId(*b"machiner");
-pub(crate) const PARACHAIN_LEASE_FUND: PalletId = PalletId(*b"parlease");
+pub(crate) const COLLATOR_DELEGATOR_POT: PalletId = PalletId(*b"mokcolat");
+pub(crate) const CORETIME_POT: PalletId = PalletId(*b"lpreward");
+pub(crate) const SUBSIDIZATION_POT: PalletId = PalletId(*b"machiner");
 pub(crate) const DE_PINSTAKING_ACCOUNT: PalletId = PalletId(*b"depinstk");
 pub(crate) const DE_PININCENTIVIZATION_ACCOUNT: PalletId = PalletId(*b"depininc");
 
@@ -127,23 +125,15 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalanceOf<TestRuntime>>
 	}
 
 	fn collators_delegators(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&COLLATOR_POT.into_account_truncating(), reward);
-	}
-
-	fn depin(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&DAPPS_POT.into_account_truncating(), reward);
+		Balances::resolve_creating(&COLLATOR_DELEGATOR_POT.into_account_truncating(), reward);
 	}
 
 	fn coretime(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&LP_POT.into_account_truncating(), reward);
+		Balances::resolve_creating(&CORETIME_POT.into_account_truncating(), reward);
 	}
 
 	fn subsidization_pool(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&MACHINE_POT.into_account_truncating(), reward);
-	}
-
-	fn parachain_lease_fund(reward: NegativeImbalanceOf<TestRuntime>) {
-		Balances::resolve_creating(&PARACHAIN_LEASE_FUND.into_account_truncating(), reward);
+		Balances::resolve_creating(&SUBSIDIZATION_POT.into_account_truncating(), reward);
 	}
 
 	fn depin_staking(reward: NegativeImbalanceOf<TestRuntime>) {

--- a/pallets/block-reward/src/tests.rs
+++ b/pallets/block-reward/src/tests.rs
@@ -20,11 +20,9 @@ fn reward_distribution_config_is_consistent() {
 	// 1
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(100),
-		depin_percent: Zero::zero(),
 		collators_delegators_percent: Zero::zero(),
 		coretime_percent: Zero::zero(),
 		subsidization_pool_percent: Zero::zero(),
-		parachain_lease_fund_percent: Zero::zero(),
 		depin_staking_percent: Zero::zero(),
 		depin_incentivization_percent: Zero::zero(),
 	};
@@ -33,24 +31,20 @@ fn reward_distribution_config_is_consistent() {
 	// 2
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Zero::zero(),
-		depin_percent: Perbill::from_percent(100),
 		collators_delegators_percent: Zero::zero(),
 		coretime_percent: Zero::zero(),
 		subsidization_pool_percent: Zero::zero(),
-		parachain_lease_fund_percent: Zero::zero(),
-		depin_staking_percent: Zero::zero(),
-		depin_incentivization_percent: Zero::zero(),
+		depin_staking_percent: Perbill::from_percent(50),
+		depin_incentivization_percent: Perbill::from_percent(50),
 	};
 	assert!(reward_config.is_consistent());
 
 	// 3
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Zero::zero(),
-		depin_percent: Zero::zero(),
 		collators_delegators_percent: Zero::zero(),
 		coretime_percent: Zero::zero(),
 		subsidization_pool_percent: Zero::zero(),
-		parachain_lease_fund_percent: Zero::zero(),
 		depin_staking_percent: Zero::zero(),
 		depin_incentivization_percent: Zero::zero(),
 	};
@@ -60,13 +54,11 @@ fn reward_distribution_config_is_consistent() {
 	// 100%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(3),
-		depin_percent: Perbill::from_percent(62),
 		collators_delegators_percent: Perbill::from_percent(25),
 		coretime_percent: Perbill::from_percent(2),
-		subsidization_pool_percent: Perbill::from_percent(4),
-		parachain_lease_fund_percent: Perbill::from_percent(4),
-		depin_staking_percent: Perbill::from_percent(0),
-		depin_incentivization_percent: Perbill::from_percent(0),
+		subsidization_pool_percent: Perbill::from_percent(8),
+		depin_staking_percent: Perbill::from_percent(31),
+		depin_incentivization_percent: Perbill::from_percent(31),
 	};
 	assert!(reward_config.is_consistent());
 }
@@ -84,13 +76,11 @@ fn reward_distribution_config_not_consistent() {
 	// 99%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(10),
-		depin_percent: Perbill::from_percent(40),
 		collators_delegators_percent: Perbill::from_percent(33),
 		coretime_percent: Perbill::from_percent(2),
-		subsidization_pool_percent: Perbill::from_percent(7),
-		parachain_lease_fund_percent: Perbill::from_percent(7),
-		depin_staking_percent: Perbill::from_percent(0),
-		depin_incentivization_percent: Perbill::from_percent(0),
+		subsidization_pool_percent: Perbill::from_percent(14),
+		depin_staking_percent: Perbill::from_percent(20),
+		depin_incentivization_percent: Perbill::from_percent(20),
 	};
 	assert!(!reward_config.is_consistent());
 
@@ -98,13 +88,11 @@ fn reward_distribution_config_not_consistent() {
 	// 101%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(10),
-		depin_percent: Perbill::from_percent(40),
 		collators_delegators_percent: Perbill::from_percent(40),
 		coretime_percent: Perbill::from_percent(2),
-		subsidization_pool_percent: Perbill::from_percent(4),
-		parachain_lease_fund_percent: Perbill::from_percent(5),
-		depin_staking_percent: Perbill::from_percent(0),
-		depin_incentivization_percent: Perbill::from_percent(0),
+		subsidization_pool_percent: Perbill::from_percent(9),
+		depin_staking_percent: Perbill::from_percent(20),
+		depin_incentivization_percent: Perbill::from_percent(20),
 	};
 	assert!(!reward_config.is_consistent());
 }
@@ -137,13 +125,11 @@ pub fn set_configuration_is_ok() {
 		// custom config so it differs from the default one
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(3),
-			depin_percent: Perbill::from_percent(28),
 			collators_delegators_percent: Perbill::from_percent(60),
 			coretime_percent: Perbill::from_percent(2),
-			subsidization_pool_percent: Perbill::from_percent(3),
-			parachain_lease_fund_percent: Perbill::from_percent(4),
-			depin_staking_percent: Perbill::from_percent(0),
-			depin_incentivization_percent: Perbill::from_percent(0),
+			subsidization_pool_percent: Perbill::from_percent(7),
+			depin_staking_percent: Perbill::from_percent(14),
+			depin_incentivization_percent: Perbill::from_percent(14),
 		};
 		assert!(reward_config.is_consistent());
 
@@ -264,13 +250,11 @@ pub fn reward_distribution_as_expected() {
 		// Prepare a custom config (easily discernable percentages for visual verification)
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(10),
-			depin_percent: Perbill::from_percent(40),
 			collators_delegators_percent: Perbill::from_percent(40),
 			coretime_percent: Perbill::from_percent(2),
-			subsidization_pool_percent: Perbill::from_percent(3),
-			parachain_lease_fund_percent: Perbill::from_percent(5),
-			depin_staking_percent: Perbill::from_percent(0),
-			depin_incentivization_percent: Perbill::from_percent(0),
+			subsidization_pool_percent: Perbill::from_percent(8),
+			depin_staking_percent: Perbill::from_percent(20),
+			depin_incentivization_percent: Perbill::from_percent(20),
 		};
 		assert!(reward_config.is_consistent());
 		assert_ok!(BlockReward::set_configuration(RuntimeOrigin::root(), reward_config.clone()));
@@ -293,13 +277,11 @@ pub fn reward_distribution_no_adjustable_part() {
 	ExternalityBuilder::build().execute_with(|| {
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(10),
-			depin_percent: Perbill::from_percent(75),
 			collators_delegators_percent: Perbill::from_percent(3),
 			coretime_percent: Perbill::from_percent(2),
-			subsidization_pool_percent: Perbill::from_percent(5),
-			parachain_lease_fund_percent: Perbill::from_percent(5),
-			depin_staking_percent: Perbill::from_percent(0),
-			depin_incentivization_percent: Perbill::from_percent(0),
+			subsidization_pool_percent: Perbill::from_percent(10),
+			depin_staking_percent: Perbill::from_percent(50),
+			depin_incentivization_percent: Perbill::from_percent(25),
 		};
 		assert!(reward_config.is_consistent());
 		assert_ok!(BlockReward::set_configuration(RuntimeOrigin::root(), reward_config.clone()));
@@ -347,11 +329,11 @@ pub fn on_unbalanceds() {
 #[derive(PartialEq, Eq, Clone, RuntimeDebug)]
 struct FreeBalanceSnapshot {
 	treasury: Balance,
-	collators: Balance,
-	dapps: Balance,
-	lp_users: Balance,
-	machines: Balance,
-	parachain_lease_fund: Balance,
+	collators_delegators: Balance,
+	coretime: Balance,
+	subsidization_pool: Balance,
+	depin_staking: Balance,
+	depin_incentivization: Balance,
 }
 
 impl FreeBalanceSnapshot {
@@ -363,20 +345,20 @@ impl FreeBalanceSnapshot {
 			treasury: <TestRuntime as Config>::Currency::free_balance(
 				&TREASURY_POT.into_account_truncating(),
 			),
-			collators: <TestRuntime as Config>::Currency::free_balance(
-				&COLLATOR_POT.into_account_truncating(),
+			collators_delegators: <TestRuntime as Config>::Currency::free_balance(
+				&COLLATOR_DELEGATOR_POT.into_account_truncating(),
 			),
-			dapps: <TestRuntime as Config>::Currency::free_balance(
-				&DAPPS_POT.into_account_truncating(),
+			coretime: <TestRuntime as Config>::Currency::free_balance(
+				&CORETIME_POT.into_account_truncating(),
 			),
-			lp_users: <TestRuntime as Config>::Currency::free_balance(
-				&LP_POT.into_account_truncating(),
+			subsidization_pool: <TestRuntime as Config>::Currency::free_balance(
+				&SUBSIDIZATION_POT.into_account_truncating(),
 			),
-			machines: <TestRuntime as Config>::Currency::free_balance(
-				&MACHINE_POT.into_account_truncating(),
+			depin_staking: <TestRuntime as Config>::Currency::free_balance(
+				&DE_PINSTAKING_ACCOUNT.into_account_truncating(),
 			),
-			parachain_lease_fund: <TestRuntime as Config>::Currency::free_balance(
-				&PARACHAIN_LEASE_FUND.into_account_truncating(),
+			depin_incentivization: <TestRuntime as Config>::Currency::free_balance(
+				&DE_PININCENTIVIZATION_ACCOUNT.into_account_truncating(),
 			),
 		}
 	}
@@ -384,11 +366,11 @@ impl FreeBalanceSnapshot {
 	/// `true` if all free balances equal `Zero`, `false` otherwise
 	fn is_zero(&self) -> bool {
 		self.treasury.is_zero() &&
-			self.collators.is_zero() &&
-			self.dapps.is_zero() &&
-			self.lp_users.is_zero() &&
-			self.machines.is_zero() &&
-			self.parachain_lease_fund.is_zero()
+		self.collators_delegators.is_zero() &&
+		self.coretime.is_zero() &&
+		self.subsidization_pool.is_zero() &&
+		self.depin_staking.is_zero() &&
+		self.depin_incentivization.is_zero()
 	}
 
 	/// Asserts that `post_reward_state` is as expected.
@@ -400,13 +382,13 @@ impl FreeBalanceSnapshot {
 		println!("rewards: {:?}", rewards);
 
 		assert_eq!(self.treasury + rewards.treasury_reward, post_reward_state.treasury);
-		assert_eq!(self.collators + rewards.collators_reward, post_reward_state.collators);
-		assert_eq!(self.dapps + rewards.dapps_reward, post_reward_state.dapps);
-		assert_eq!(self.lp_users + rewards.lp_reward, post_reward_state.lp_users);
-		assert_eq!(self.machines + rewards.machines_reward, post_reward_state.machines);
+		assert_eq!(self.collators_delegators + rewards.collators_delegators_reward, post_reward_state.collators_delegators);
+		assert_eq!(self.coretime + rewards.coretime_reward, post_reward_state.coretime);
+		assert_eq!(self.subsidization_pool + rewards.subsidization_pool_reward, post_reward_state.subsidization_pool);
+		assert_eq!(self.depin_staking + rewards.depin_staking_reward, post_reward_state.depin_staking);
 		assert_eq!(
-			self.parachain_lease_fund + rewards.parachain_lease_fund_reward,
-			post_reward_state.parachain_lease_fund
+			self.depin_incentivization + rewards.depin_incentivization_reward,
+			post_reward_state.depin_incentivization
 		);
 	}
 }
@@ -415,11 +397,11 @@ impl FreeBalanceSnapshot {
 #[derive(PartialEq, Eq, Clone, RuntimeDebug)]
 struct Rewards {
 	treasury_reward: Balance,
-	dapps_reward: Balance,
-	collators_reward: Balance,
-	lp_reward: Balance,
-	machines_reward: Balance,
-	parachain_lease_fund_reward: Balance,
+	collators_delegators_reward: Balance,
+	coretime_reward: Balance,
+	subsidization_pool_reward: Balance,
+	depin_staking_reward: Balance,
+	depin_incentivization_reward: Balance,
 }
 
 impl Rewards {
@@ -427,19 +409,19 @@ impl Rewards {
 	/// Method assumes that total issuance will be increased by `BLOCK_REWARD`.
 	fn calculate(reward_config: &RewardDistributionConfig) -> Self {
 		let treasury_reward = reward_config.treasury_percent * BLOCK_REWARD;
-		let dapps_reward = reward_config.depin_percent * BLOCK_REWARD;
-		let collators_reward = reward_config.collators_delegators_percent * BLOCK_REWARD;
-		let lp_reward = reward_config.coretime_percent * BLOCK_REWARD;
-		let machines_reward = reward_config.subsidization_pool_percent * BLOCK_REWARD;
-		let parachain_lease_fund_reward = reward_config.parachain_lease_fund_percent * BLOCK_REWARD;
+		let collators_delegators_reward = reward_config.collators_delegators_percent * BLOCK_REWARD;
+		let coretime_reward = reward_config.coretime_percent * BLOCK_REWARD;
+		let subsidization_pool_reward = reward_config.subsidization_pool_percent * BLOCK_REWARD;
+		let depin_staking_reward = reward_config.depin_staking_percent * BLOCK_REWARD;
+		let depin_incentivization_reward = reward_config.depin_incentivization_percent * BLOCK_REWARD;
 
 		Self {
 			treasury_reward,
-			dapps_reward,
-			collators_reward,
-			lp_reward,
-			machines_reward,
-			parachain_lease_fund_reward,
+			collators_delegators_reward,
+			coretime_reward,
+			subsidization_pool_reward,
+			depin_staking_reward,
+			depin_incentivization_reward
 		}
 	}
 }

--- a/pallets/block-reward/src/tests.rs
+++ b/pallets/block-reward/src/tests.rs
@@ -20,10 +20,10 @@ fn reward_distribution_config_is_consistent() {
 	// 1
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(100),
-		dapps_percent: Zero::zero(),
-		collators_percent: Zero::zero(),
-		lp_percent: Zero::zero(),
-		machines_percent: Zero::zero(),
+		depin_percent: Zero::zero(),
+		collators_delegators_percent: Zero::zero(),
+		coretime_percent: Zero::zero(),
+		subsidization_pool_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
 		depin_staking_percent: Zero::zero(),
 		depin_incentivization_percent: Zero::zero(),
@@ -33,10 +33,10 @@ fn reward_distribution_config_is_consistent() {
 	// 2
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Zero::zero(),
-		dapps_percent: Perbill::from_percent(100),
-		collators_percent: Zero::zero(),
-		lp_percent: Zero::zero(),
-		machines_percent: Zero::zero(),
+		depin_percent: Perbill::from_percent(100),
+		collators_delegators_percent: Zero::zero(),
+		coretime_percent: Zero::zero(),
+		subsidization_pool_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
 		depin_staking_percent: Zero::zero(),
 		depin_incentivization_percent: Zero::zero(),
@@ -46,10 +46,10 @@ fn reward_distribution_config_is_consistent() {
 	// 3
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Zero::zero(),
-		dapps_percent: Zero::zero(),
-		collators_percent: Zero::zero(),
-		lp_percent: Zero::zero(),
-		machines_percent: Zero::zero(),
+		depin_percent: Zero::zero(),
+		collators_delegators_percent: Zero::zero(),
+		coretime_percent: Zero::zero(),
+		subsidization_pool_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
 		depin_staking_percent: Zero::zero(),
 		depin_incentivization_percent: Zero::zero(),
@@ -60,10 +60,10 @@ fn reward_distribution_config_is_consistent() {
 	// 100%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(3),
-		dapps_percent: Perbill::from_percent(62),
-		collators_percent: Perbill::from_percent(25),
-		lp_percent: Perbill::from_percent(2),
-		machines_percent: Perbill::from_percent(4),
+		depin_percent: Perbill::from_percent(62),
+		collators_delegators_percent: Perbill::from_percent(25),
+		coretime_percent: Perbill::from_percent(2),
+		subsidization_pool_percent: Perbill::from_percent(4),
 		parachain_lease_fund_percent: Perbill::from_percent(4),
 		depin_staking_percent: Perbill::from_percent(0),
 		depin_incentivization_percent: Perbill::from_percent(0),
@@ -84,10 +84,10 @@ fn reward_distribution_config_not_consistent() {
 	// 99%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(10),
-		dapps_percent: Perbill::from_percent(40),
-		collators_percent: Perbill::from_percent(33),
-		lp_percent: Perbill::from_percent(2),
-		machines_percent: Perbill::from_percent(7),
+		depin_percent: Perbill::from_percent(40),
+		collators_delegators_percent: Perbill::from_percent(33),
+		coretime_percent: Perbill::from_percent(2),
+		subsidization_pool_percent: Perbill::from_percent(7),
 		parachain_lease_fund_percent: Perbill::from_percent(7),
 		depin_staking_percent: Perbill::from_percent(0),
 		depin_incentivization_percent: Perbill::from_percent(0),
@@ -98,10 +98,10 @@ fn reward_distribution_config_not_consistent() {
 	// 101%
 	let reward_config = RewardDistributionConfig {
 		treasury_percent: Perbill::from_percent(10),
-		dapps_percent: Perbill::from_percent(40),
-		collators_percent: Perbill::from_percent(40),
-		lp_percent: Perbill::from_percent(2),
-		machines_percent: Perbill::from_percent(4),
+		depin_percent: Perbill::from_percent(40),
+		collators_delegators_percent: Perbill::from_percent(40),
+		coretime_percent: Perbill::from_percent(2),
+		subsidization_pool_percent: Perbill::from_percent(4),
 		parachain_lease_fund_percent: Perbill::from_percent(5),
 		depin_staking_percent: Perbill::from_percent(0),
 		depin_incentivization_percent: Perbill::from_percent(0),
@@ -137,10 +137,10 @@ pub fn set_configuration_is_ok() {
 		// custom config so it differs from the default one
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(3),
-			dapps_percent: Perbill::from_percent(28),
-			collators_percent: Perbill::from_percent(60),
-			lp_percent: Perbill::from_percent(2),
-			machines_percent: Perbill::from_percent(3),
+			depin_percent: Perbill::from_percent(28),
+			collators_delegators_percent: Perbill::from_percent(60),
+			coretime_percent: Perbill::from_percent(2),
+			subsidization_pool_percent: Perbill::from_percent(3),
 			parachain_lease_fund_percent: Perbill::from_percent(4),
 			depin_staking_percent: Perbill::from_percent(0),
 			depin_incentivization_percent: Perbill::from_percent(0),
@@ -264,10 +264,10 @@ pub fn reward_distribution_as_expected() {
 		// Prepare a custom config (easily discernable percentages for visual verification)
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(10),
-			dapps_percent: Perbill::from_percent(40),
-			collators_percent: Perbill::from_percent(40),
-			lp_percent: Perbill::from_percent(2),
-			machines_percent: Perbill::from_percent(3),
+			depin_percent: Perbill::from_percent(40),
+			collators_delegators_percent: Perbill::from_percent(40),
+			coretime_percent: Perbill::from_percent(2),
+			subsidization_pool_percent: Perbill::from_percent(3),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
 			depin_staking_percent: Perbill::from_percent(0),
 			depin_incentivization_percent: Perbill::from_percent(0),
@@ -293,10 +293,10 @@ pub fn reward_distribution_no_adjustable_part() {
 	ExternalityBuilder::build().execute_with(|| {
 		let reward_config = RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(10),
-			dapps_percent: Perbill::from_percent(75),
-			collators_percent: Perbill::from_percent(3),
-			lp_percent: Perbill::from_percent(2),
-			machines_percent: Perbill::from_percent(5),
+			depin_percent: Perbill::from_percent(75),
+			collators_delegators_percent: Perbill::from_percent(3),
+			coretime_percent: Perbill::from_percent(2),
+			subsidization_pool_percent: Perbill::from_percent(5),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
 			depin_staking_percent: Perbill::from_percent(0),
 			depin_incentivization_percent: Perbill::from_percent(0),
@@ -427,10 +427,10 @@ impl Rewards {
 	/// Method assumes that total issuance will be increased by `BLOCK_REWARD`.
 	fn calculate(reward_config: &RewardDistributionConfig) -> Self {
 		let treasury_reward = reward_config.treasury_percent * BLOCK_REWARD;
-		let dapps_reward = reward_config.dapps_percent * BLOCK_REWARD;
-		let collators_reward = reward_config.collators_percent * BLOCK_REWARD;
-		let lp_reward = reward_config.lp_percent * BLOCK_REWARD;
-		let machines_reward = reward_config.machines_percent * BLOCK_REWARD;
+		let dapps_reward = reward_config.depin_percent * BLOCK_REWARD;
+		let collators_reward = reward_config.collators_delegators_percent * BLOCK_REWARD;
+		let lp_reward = reward_config.coretime_percent * BLOCK_REWARD;
+		let machines_reward = reward_config.subsidization_pool_percent * BLOCK_REWARD;
 		let parachain_lease_fund_reward = reward_config.parachain_lease_fund_percent * BLOCK_REWARD;
 
 		Self {

--- a/pallets/block-reward/src/tests.rs
+++ b/pallets/block-reward/src/tests.rs
@@ -25,6 +25,8 @@ fn reward_distribution_config_is_consistent() {
 		lp_percent: Zero::zero(),
 		machines_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
+		depin_staking_percent: Zero::zero(),
+		depin_incentivization_percent: Zero::zero(),
 	};
 	assert!(reward_config.is_consistent());
 
@@ -36,6 +38,8 @@ fn reward_distribution_config_is_consistent() {
 		lp_percent: Zero::zero(),
 		machines_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
+		depin_staking_percent: Zero::zero(),
+		depin_incentivization_percent: Zero::zero(),
 	};
 	assert!(reward_config.is_consistent());
 
@@ -47,6 +51,8 @@ fn reward_distribution_config_is_consistent() {
 		lp_percent: Zero::zero(),
 		machines_percent: Zero::zero(),
 		parachain_lease_fund_percent: Zero::zero(),
+		depin_staking_percent: Zero::zero(),
+		depin_incentivization_percent: Zero::zero(),
 	};
 	assert!(!reward_config.is_consistent());
 
@@ -59,6 +65,8 @@ fn reward_distribution_config_is_consistent() {
 		lp_percent: Perbill::from_percent(2),
 		machines_percent: Perbill::from_percent(4),
 		parachain_lease_fund_percent: Perbill::from_percent(4),
+		depin_staking_percent: Perbill::from_percent(0),
+		depin_incentivization_percent: Perbill::from_percent(0),
 	};
 	assert!(reward_config.is_consistent());
 }
@@ -81,6 +89,8 @@ fn reward_distribution_config_not_consistent() {
 		lp_percent: Perbill::from_percent(2),
 		machines_percent: Perbill::from_percent(7),
 		parachain_lease_fund_percent: Perbill::from_percent(7),
+		depin_staking_percent: Perbill::from_percent(0),
+		depin_incentivization_percent: Perbill::from_percent(0),
 	};
 	assert!(!reward_config.is_consistent());
 
@@ -93,6 +103,8 @@ fn reward_distribution_config_not_consistent() {
 		lp_percent: Perbill::from_percent(2),
 		machines_percent: Perbill::from_percent(4),
 		parachain_lease_fund_percent: Perbill::from_percent(5),
+		depin_staking_percent: Perbill::from_percent(0),
+		depin_incentivization_percent: Perbill::from_percent(0),
 	};
 	assert!(!reward_config.is_consistent());
 }
@@ -130,6 +142,8 @@ pub fn set_configuration_is_ok() {
 			lp_percent: Perbill::from_percent(2),
 			machines_percent: Perbill::from_percent(3),
 			parachain_lease_fund_percent: Perbill::from_percent(4),
+			depin_staking_percent: Perbill::from_percent(0),
+			depin_incentivization_percent: Perbill::from_percent(0),
 		};
 		assert!(reward_config.is_consistent());
 
@@ -255,6 +269,8 @@ pub fn reward_distribution_as_expected() {
 			lp_percent: Perbill::from_percent(2),
 			machines_percent: Perbill::from_percent(3),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
+			depin_staking_percent: Perbill::from_percent(0),
+			depin_incentivization_percent: Perbill::from_percent(0),
 		};
 		assert!(reward_config.is_consistent());
 		assert_ok!(BlockReward::set_configuration(RuntimeOrigin::root(), reward_config.clone()));
@@ -282,6 +298,8 @@ pub fn reward_distribution_no_adjustable_part() {
 			lp_percent: Perbill::from_percent(2),
 			machines_percent: Perbill::from_percent(5),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
+			depin_staking_percent: Perbill::from_percent(0),
+			depin_incentivization_percent: Perbill::from_percent(0),
 		};
 		assert!(reward_config.is_consistent());
 		assert_ok!(BlockReward::set_configuration(RuntimeOrigin::root(), reward_config.clone()));

--- a/pallets/block-reward/src/tests.rs
+++ b/pallets/block-reward/src/tests.rs
@@ -366,11 +366,11 @@ impl FreeBalanceSnapshot {
 	/// `true` if all free balances equal `Zero`, `false` otherwise
 	fn is_zero(&self) -> bool {
 		self.treasury.is_zero() &&
-		self.collators_delegators.is_zero() &&
-		self.coretime.is_zero() &&
-		self.subsidization_pool.is_zero() &&
-		self.depin_staking.is_zero() &&
-		self.depin_incentivization.is_zero()
+			self.collators_delegators.is_zero() &&
+			self.coretime.is_zero() &&
+			self.subsidization_pool.is_zero() &&
+			self.depin_staking.is_zero() &&
+			self.depin_incentivization.is_zero()
 	}
 
 	/// Asserts that `post_reward_state` is as expected.
@@ -382,10 +382,19 @@ impl FreeBalanceSnapshot {
 		println!("rewards: {:?}", rewards);
 
 		assert_eq!(self.treasury + rewards.treasury_reward, post_reward_state.treasury);
-		assert_eq!(self.collators_delegators + rewards.collators_delegators_reward, post_reward_state.collators_delegators);
+		assert_eq!(
+			self.collators_delegators + rewards.collators_delegators_reward,
+			post_reward_state.collators_delegators
+		);
 		assert_eq!(self.coretime + rewards.coretime_reward, post_reward_state.coretime);
-		assert_eq!(self.subsidization_pool + rewards.subsidization_pool_reward, post_reward_state.subsidization_pool);
-		assert_eq!(self.depin_staking + rewards.depin_staking_reward, post_reward_state.depin_staking);
+		assert_eq!(
+			self.subsidization_pool + rewards.subsidization_pool_reward,
+			post_reward_state.subsidization_pool
+		);
+		assert_eq!(
+			self.depin_staking + rewards.depin_staking_reward,
+			post_reward_state.depin_staking
+		);
 		assert_eq!(
 			self.depin_incentivization + rewards.depin_incentivization_reward,
 			post_reward_state.depin_incentivization
@@ -413,7 +422,8 @@ impl Rewards {
 		let coretime_reward = reward_config.coretime_percent * BLOCK_REWARD;
 		let subsidization_pool_reward = reward_config.subsidization_pool_percent * BLOCK_REWARD;
 		let depin_staking_reward = reward_config.depin_staking_percent * BLOCK_REWARD;
-		let depin_incentivization_reward = reward_config.depin_incentivization_percent * BLOCK_REWARD;
+		let depin_incentivization_reward =
+			reward_config.depin_incentivization_percent * BLOCK_REWARD;
 
 		Self {
 			treasury_reward,
@@ -421,7 +431,7 @@ impl Rewards {
 			coretime_reward,
 			subsidization_pool_reward,
 			depin_staking_reward,
-			depin_incentivization_reward
+			depin_incentivization_reward,
 		}
 	}
 }

--- a/pallets/block-reward/src/types.rs
+++ b/pallets/block-reward/src/types.rs
@@ -34,6 +34,12 @@ pub trait BeneficiaryPayout<Imbalance> {
 
 	/// Payout Parachain
 	fn parachain_lease_fund(reward: Imbalance);
+
+	/// Payout DePIN staking rewards
+	fn depin_staking(reward: Imbalance);
+
+	/// Payout DePIN incentivization
+	fn depin_incentivization(reward: Imbalance);
 }
 
 /// After next next version, we can remove this RewardDistributionConfigV0
@@ -100,6 +106,12 @@ pub struct RewardDistributionConfig {
 	/// Percentage of reward that goes to parachain lease fund
 	#[codec(compact)]
 	pub parachain_lease_fund_percent: Perbill,
+	/// Percentage of rewards that goes to DePIN staking
+	#[codec(compact)]
+	pub depin_staking_percent: Perbill,
+	/// Percentage of rewards that goes to DePIN incentivization
+	#[codec(compact)]
+	pub depin_incentivization_percent: Perbill,
 }
 
 impl Default for RewardDistributionConfig {
@@ -113,6 +125,8 @@ impl Default for RewardDistributionConfig {
 			lp_percent: Perbill::from_percent(20),
 			machines_percent: Perbill::from_percent(5),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
+			depin_staking_percent: Perbill::from_percent(0),
+			depin_incentivization_percent: Perbill::from_percent(0),
 		}
 	}
 }

--- a/pallets/block-reward/src/types.rs
+++ b/pallets/block-reward/src/types.rs
@@ -119,14 +119,14 @@ impl Default for RewardDistributionConfig {
 	/// Should be overriden by desired params.
 	fn default() -> Self {
 		RewardDistributionConfig {
-			treasury_percent: Perbill::from_percent(15),
-			depin_percent: Perbill::from_percent(45),
-			collators_delegators_percent: Perbill::from_percent(10),
-			coretime_percent: Perbill::from_percent(20),
+			treasury_percent: Perbill::from_percent(25),
+			depin_percent: Perbill::from_percent(0),
+			collators_delegators_percent: Perbill::from_percent(40),
+			coretime_percent: Perbill::from_percent(10),
 			subsidization_pool_percent: Perbill::from_percent(5),
-			parachain_lease_fund_percent: Perbill::from_percent(5),
-			depin_staking_percent: Perbill::from_percent(0),
-			depin_incentivization_percent: Perbill::from_percent(0),
+			parachain_lease_fund_percent: Perbill::from_percent(0),
+			depin_staking_percent: Perbill::from_percent(5),
+			depin_incentivization_percent: Perbill::from_percent(15),
 		}
 	}
 }
@@ -145,6 +145,8 @@ impl RewardDistributionConfig {
 			&self.coretime_percent,
 			&self.subsidization_pool_percent,
 			&self.parachain_lease_fund_percent,
+			&self.depin_staking_percent,
+			&self.depin_incentivization_percent,
 		];
 
 		let mut accumulator = Perbill::zero();

--- a/pallets/block-reward/src/types.rs
+++ b/pallets/block-reward/src/types.rs
@@ -21,16 +21,16 @@ pub trait BeneficiaryPayout<Imbalance> {
 	fn treasury(reward: Imbalance);
 
 	/// Payout reward to the collators
-	fn collators(reward: Imbalance);
+	fn collators_delegators(reward: Imbalance);
 
 	/// Payout reward to dapps staking
-	fn dapps_staking(dapps: Imbalance);
+	fn depin(dapps: Imbalance);
 
 	/// Payout LP users
-	fn lp_users(reward: Imbalance);
+	fn coretime(reward: Imbalance);
 
 	/// Payout Machines
-	fn machines(reward: Imbalance);
+	fn subsidization_pool(reward: Imbalance);
 
 	/// Payout Parachain
 	fn parachain_lease_fund(reward: Imbalance);

--- a/pallets/block-reward/src/types.rs
+++ b/pallets/block-reward/src/types.rs
@@ -23,17 +23,11 @@ pub trait BeneficiaryPayout<Imbalance> {
 	/// Payout reward to the collators
 	fn collators_delegators(reward: Imbalance);
 
-	/// Payout reward to dapps staking
-	fn depin(dapps: Imbalance);
-
 	/// Payout LP users
 	fn coretime(reward: Imbalance);
 
 	/// Payout Machines
 	fn subsidization_pool(reward: Imbalance);
-
-	/// Payout Parachain
-	fn parachain_lease_fund(reward: Imbalance);
 
 	/// Payout DePIN staking rewards
 	fn depin_staking(reward: Imbalance);
@@ -91,9 +85,6 @@ pub struct RewardDistributionConfig {
 	/// Base percentage of reward that goes to treasury
 	#[codec(compact)]
 	pub treasury_percent: Perbill,
-	/// Percentage of rewards that goes to DePIN apps
-	#[codec(compact)]
-	pub depin_percent: Perbill,
 	/// Percentage of reward that goes to collators and delegators
 	#[codec(compact)]
 	pub collators_delegators_percent: Perbill,
@@ -103,9 +94,6 @@ pub struct RewardDistributionConfig {
 	/// Percentage of reward that goes to subsidization pool
 	#[codec(compact)]
 	pub subsidization_pool_percent: Perbill,
-	/// Percentage of reward that goes to parachain lease fund
-	#[codec(compact)]
-	pub parachain_lease_fund_percent: Perbill,
 	/// Percentage of rewards that goes to DePIN staking
 	#[codec(compact)]
 	pub depin_staking_percent: Perbill,
@@ -120,11 +108,9 @@ impl Default for RewardDistributionConfig {
 	fn default() -> Self {
 		RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(25),
-			depin_percent: Perbill::from_percent(0),
 			collators_delegators_percent: Perbill::from_percent(40),
 			coretime_percent: Perbill::from_percent(10),
 			subsidization_pool_percent: Perbill::from_percent(5),
-			parachain_lease_fund_percent: Perbill::from_percent(0),
 			depin_staking_percent: Perbill::from_percent(5),
 			depin_incentivization_percent: Perbill::from_percent(15),
 		}
@@ -140,11 +126,9 @@ impl RewardDistributionConfig {
 
 		let variables = vec![
 			&self.treasury_percent,
-			&self.depin_percent,
 			&self.collators_delegators_percent,
 			&self.coretime_percent,
 			&self.subsidization_pool_percent,
-			&self.parachain_lease_fund_percent,
 			&self.depin_staking_percent,
 			&self.depin_incentivization_percent,
 		];

--- a/pallets/block-reward/src/types.rs
+++ b/pallets/block-reward/src/types.rs
@@ -91,18 +91,18 @@ pub struct RewardDistributionConfig {
 	/// Base percentage of reward that goes to treasury
 	#[codec(compact)]
 	pub treasury_percent: Perbill,
-	/// Percentage of rewards that goes to dApps
+	/// Percentage of rewards that goes to DePIN apps
 	#[codec(compact)]
-	pub dapps_percent: Perbill,
-	/// Percentage of reward that goes to collators
+	pub depin_percent: Perbill,
+	/// Percentage of reward that goes to collators and delegators
 	#[codec(compact)]
-	pub collators_percent: Perbill,
-	/// Percentage of reward that goes to lp users
+	pub collators_delegators_percent: Perbill,
+	/// Percentage of reward that goes to coretime
 	#[codec(compact)]
-	pub lp_percent: Perbill,
-	/// Percentage of reward that goes to machines
+	pub coretime_percent: Perbill,
+	/// Percentage of reward that goes to subsidization pool
 	#[codec(compact)]
-	pub machines_percent: Perbill,
+	pub subsidization_pool_percent: Perbill,
 	/// Percentage of reward that goes to parachain lease fund
 	#[codec(compact)]
 	pub parachain_lease_fund_percent: Perbill,
@@ -120,10 +120,10 @@ impl Default for RewardDistributionConfig {
 	fn default() -> Self {
 		RewardDistributionConfig {
 			treasury_percent: Perbill::from_percent(15),
-			dapps_percent: Perbill::from_percent(45),
-			collators_percent: Perbill::from_percent(10),
-			lp_percent: Perbill::from_percent(20),
-			machines_percent: Perbill::from_percent(5),
+			depin_percent: Perbill::from_percent(45),
+			collators_delegators_percent: Perbill::from_percent(10),
+			coretime_percent: Perbill::from_percent(20),
+			subsidization_pool_percent: Perbill::from_percent(5),
 			parachain_lease_fund_percent: Perbill::from_percent(5),
 			depin_staking_percent: Perbill::from_percent(0),
 			depin_incentivization_percent: Perbill::from_percent(0),
@@ -140,10 +140,10 @@ impl RewardDistributionConfig {
 
 		let variables = vec![
 			&self.treasury_percent,
-			&self.dapps_percent,
-			&self.collators_percent,
-			&self.lp_percent,
-			&self.machines_percent,
+			&self.depin_percent,
+			&self.collators_delegators_percent,
+			&self.coretime_percent,
+			&self.subsidization_pool_percent,
 			&self.parachain_lease_fund_percent,
 		];
 

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -857,6 +857,10 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 	fn machines(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
+
+	fn depin_incentivization(_reward: NegativeImbalance) {}
+
+	fn depin_staking(_reward: NegativeImbalance) {}
 }
 
 parameter_types! {

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -850,13 +850,9 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn depin(_reward: NegativeImbalance) {}
-
 	fn coretime(_reward: NegativeImbalance) {}
 
 	fn subsidization_pool(_reward: NegativeImbalance) {}
-
-	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 
 	fn depin_incentivization(_reward: NegativeImbalance) {}
 

--- a/runtime/agung/src/lib.rs
+++ b/runtime/agung/src/lib.rs
@@ -846,15 +846,15 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToTreasuryPot::on_unbalanced(reward);
 	}
 
-	fn collators(reward: NegativeImbalance) {
+	fn collators_delegators(reward: NegativeImbalance) {
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn dapps_staking(_reward: NegativeImbalance) {}
+	fn depin(_reward: NegativeImbalance) {}
 
-	fn lp_users(_reward: NegativeImbalance) {}
+	fn coretime(_reward: NegativeImbalance) {}
 
-	fn machines(_reward: NegativeImbalance) {}
+	fn subsidization_pool(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -854,6 +854,10 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 	fn machines(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
+
+	fn depin_incentivization(_reward: NegativeImbalance) {}
+
+	fn depin_staking(_reward: NegativeImbalance) {}
 }
 
 parameter_types! {

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -843,15 +843,15 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToTreasuryPot::on_unbalanced(reward);
 	}
 
-	fn collators(reward: NegativeImbalance) {
+	fn collators_delegators(reward: NegativeImbalance) {
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn dapps_staking(_reward: NegativeImbalance) {}
+	fn depin(_reward: NegativeImbalance) {}
 
-	fn lp_users(_reward: NegativeImbalance) {}
+	fn coretime(_reward: NegativeImbalance) {}
 
-	fn machines(_reward: NegativeImbalance) {}
+	fn subsidization_pool(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -847,13 +847,9 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn depin(_reward: NegativeImbalance) {}
-
 	fn coretime(_reward: NegativeImbalance) {}
 
 	fn subsidization_pool(_reward: NegativeImbalance) {}
-
-	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 
 	fn depin_incentivization(_reward: NegativeImbalance) {}
 

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -864,6 +864,10 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 	}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
+
+	fn depin_staking(_reward: NegativeImbalance) {}
+
+	fn depin_incentivization(_reward: NegativeImbalance) {}
 }
 
 parameter_types! {

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -164,7 +164,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 12,
+	spec_version: 17,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -853,8 +853,6 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn depin(_reward: NegativeImbalance) {}
-
 	fn coretime(_reward: NegativeImbalance) {}
 
 	fn subsidization_pool(reward: NegativeImbalance) {
@@ -862,8 +860,6 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToMachinePot::on_unbalanced(reward);
 		PeaqMor::log_block_rewards(amount);
 	}
-
-	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 
 	fn depin_staking(_reward: NegativeImbalance) {}
 

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -849,15 +849,15 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToTreasuryPot::on_unbalanced(reward);
 	}
 
-	fn collators(reward: NegativeImbalance) {
+	fn collators_delegators(reward: NegativeImbalance) {
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn dapps_staking(_reward: NegativeImbalance) {}
+	fn depin(_reward: NegativeImbalance) {}
 
-	fn lp_users(_reward: NegativeImbalance) {}
+	fn coretime(_reward: NegativeImbalance) {}
 
-	fn machines(reward: NegativeImbalance) {
+	fn subsidization_pool(reward: NegativeImbalance) {
 		let amount = reward.peek();
 		ToMachinePot::on_unbalanced(reward);
 		PeaqMor::log_block_rewards(amount);

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -853,6 +853,10 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 	fn machines(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
+
+	fn depin_incentivization(_reward: NegativeImbalance) {}
+
+	fn depin_staking(_reward: NegativeImbalance) {}
 }
 
 parameter_types! {

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -842,15 +842,15 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToTreasuryPot::on_unbalanced(reward);
 	}
 
-	fn collators(reward: NegativeImbalance) {
+	fn collators_delegators(reward: NegativeImbalance) {
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn dapps_staking(_reward: NegativeImbalance) {}
+	fn depin(_reward: NegativeImbalance) {}
 
-	fn lp_users(_reward: NegativeImbalance) {}
+	fn coretime(_reward: NegativeImbalance) {}
 
-	fn machines(_reward: NegativeImbalance) {}
+	fn subsidization_pool(_reward: NegativeImbalance) {}
 
 	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -846,13 +846,9 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn depin(_reward: NegativeImbalance) {}
-
 	fn coretime(_reward: NegativeImbalance) {}
 
 	fn subsidization_pool(_reward: NegativeImbalance) {}
-
-	fn parachain_lease_fund(_reward: NegativeImbalance) {}
 
 	fn depin_incentivization(_reward: NegativeImbalance) {}
 


### PR DESCRIPTION
This PR is link to [this task](https://app.asana.com/0/inbox/1206767151689496).

You can have a look to the specs [here](https://eotlabs.slab.com/posts/rewards-split-1aq1czh8)

Summary: This PR aim to change the ratio of block reward splitting. It will affect the dev/krest/peaq network. Fields were added to the `RewardDistributionConfig` in order to split the reward for DePIN. The code for the `BeneficiaryPayout` still need to be added.