### PR TITLE
Add differents pots for the reward split

### DIFF
--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -705,6 +705,10 @@ parameter_types! {
 	pub const AssetAdminId: PalletId = PalletId(*b"AssetAdm");
 	pub const PotStakeId: PalletId = PalletId(*b"PotStake");
 	pub const PotTreasuryId: PalletId = TreasuryPalletId::get();
+	pub const PotCoretimeId: PalletId = PalletId(*b"PotCoret");
+	pub const PotSubsidizationId: PalletId = PalletId(*b"PotSubsi");
+	pub const PotDepinStakingId: PalletId = PalletId(*b"PotDPStk");
+	pub const PotDepinIncentivisationId: PalletId = PalletId(*b"PotDPInc");
 }
 
 impl pallet_authorship::Config for Runtime {
@@ -821,6 +825,10 @@ macro_rules! impl_to_pot_adapter {
 }
 
 impl_to_pot_adapter!(ToStakingPot, PotStakeId, NegativeImbalance);
+impl_to_pot_adapter!(ToCoreTimePot, PotCoretimeId, NegativeImbalance);
+impl_to_pot_adapter!(ToSubsidizationPot, PotSubsidizationId, NegativeImbalance);
+impl_to_pot_adapter!(ToDepinStakingPot, PotDepinStakingId, NegativeImbalance);
+impl_to_pot_adapter!(ToDepinIncentivizationPot, PotDepinIncentivisationId, NegativeImbalance);
 
 pub struct ToTreasuryPot;
 impl OnUnbalanced<NegativeImbalance> for ToTreasuryPot {
@@ -847,13 +855,21 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn coretime(_reward: NegativeImbalance) {}
+	fn coretime(reward: NegativeImbalance) {
+		ToCoreTimePot::on_unbalanced(reward);
+	}
 
-	fn subsidization_pool(_reward: NegativeImbalance) {}
+	fn subsidization_pool(reward: NegativeImbalance) {
+		ToSubsidizationPot::on_unbalanced(reward);
+	}
 
-	fn depin_incentivization(_reward: NegativeImbalance) {}
+	fn depin_staking(reward: NegativeImbalance) {
+		ToDepinStakingPot::on_unbalanced(reward);
+	}
 
-	fn depin_staking(_reward: NegativeImbalance) {}
+	fn depin_incentivization(reward: NegativeImbalance) {
+		ToDepinIncentivizationPot::on_unbalanced(reward);
+	}
 }
 
 parameter_types! {
@@ -864,6 +880,10 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 	vec![
 		PotStakeId::get().into_account_truncating(),
 		PotTreasuryId::get().into_account_truncating(),
+		PotCoretimeId::get().into_account_truncating(),
+		PotSubsidizationId::get().into_account_truncating(),
+		PotDepinStakingId::get().into_account_truncating(),
+		PotDepinIncentivisationId::get().into_account_truncating(),
 	]
 }
 
@@ -878,6 +898,10 @@ parameter_types! {
 	pub PeaqAssetAdm: AccountId = AssetAdminId::get().into_account_truncating();
 	pub PeaqPotAccount: AccountId = PotStakeId::get().into_account_truncating();
 	pub PeaqTreasuryAccount: AccountId = TreasuryPalletId::get().into_account_truncating();
+	pub PeaqCoretimeAccount: AccountId = PotCoretimeId::get().into_account_truncating();
+	pub PeaqSubsidizationAccount: AccountId = PotSubsidizationId::get().into_account_truncating();
+	pub PeaqDepinStakingAccount: AccountId = PotDepinStakingId::get().into_account_truncating();
+	pub PeaqDepinIncentivisationAccount: AccountId = PotDepinIncentivisationId::get().into_account_truncating();
 }
 
 impl peaq_pallet_rbac::Config for Runtime {

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -861,7 +861,6 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 
 	fn coretime(reward: NegativeImbalance) {
 		ToCoreTimePot::on_unbalanced(reward);
-		impl_to_pot_adapter!(ToMachinePot, PotMorId, NegativeImbalance);
 	}
 
 	fn subsidization_pool(reward: NegativeImbalance) {

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -711,6 +711,9 @@ parameter_types! {
 	pub const PotStakeId: PalletId = PalletId(*b"PotStake");
 	pub const PotMorId: PalletId = PalletId(*b"PotMchOw");
 	pub const PotTreasuryId: PalletId = TreasuryPalletId::get();
+	pub const PotCoretimeId: PalletId = PalletId(*b"PotCoret");
+	pub const PotSubsidizationId: PalletId = PalletId(*b"PotSubsi");
+	pub const PotDepinStakingId: PalletId = PalletId(*b"PotDPStk");
 }
 
 impl pallet_authorship::Config for Runtime {
@@ -827,6 +830,9 @@ macro_rules! impl_to_pot_adapter {
 
 impl_to_pot_adapter!(ToStakingPot, PotStakeId, NegativeImbalance);
 impl_to_pot_adapter!(ToMachinePot, PotMorId, NegativeImbalance);
+impl_to_pot_adapter!(ToCoreTimePot, PotCoretimeId, NegativeImbalance);
+impl_to_pot_adapter!(ToSubsidizationPot, PotSubsidizationId, NegativeImbalance);
+impl_to_pot_adapter!(ToDepinStakingPot, PotDepinStakingId, NegativeImbalance);
 
 pub struct ToTreasuryPot;
 impl OnUnbalanced<NegativeImbalance> for ToTreasuryPot {
@@ -853,17 +859,24 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn coretime(_reward: NegativeImbalance) {}
+	fn coretime(reward: NegativeImbalance) {
+		ToCoreTimePot::on_unbalanced(reward);
+		impl_to_pot_adapter!(ToMachinePot, PotMorId, NegativeImbalance);
+	}
 
 	fn subsidization_pool(reward: NegativeImbalance) {
+		ToSubsidizationPot::on_unbalanced(reward);
+	}
+
+	fn depin_staking(reward: NegativeImbalance) {
+		ToDepinStakingPot::on_unbalanced(reward);
+	}
+
+	fn depin_incentivization(reward: NegativeImbalance) {
 		let amount = reward.peek();
 		ToMachinePot::on_unbalanced(reward);
 		PeaqMor::log_block_rewards(amount);
 	}
-
-	fn depin_staking(_reward: NegativeImbalance) {}
-
-	fn depin_incentivization(_reward: NegativeImbalance) {}
 }
 
 parameter_types! {
@@ -875,6 +888,9 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 		PotStakeId::get().into_account_truncating(),
 		PotMorId::get().into_account_truncating(),
 		PotTreasuryId::get().into_account_truncating(),
+		PotCoretimeId::get().into_account_truncating(),
+		PotSubsidizationId::get().into_account_truncating(),
+		PotDepinStakingId::get().into_account_truncating(),
 	]
 }
 
@@ -889,6 +905,9 @@ parameter_types! {
 	pub PeaqAssetAdm: AccountId = AssetAdminId::get().into_account_truncating();
 	pub PeaqPotAccount: AccountId = PotStakeId::get().into_account_truncating();
 	pub PeaqTreasuryAccount: AccountId = TreasuryPalletId::get().into_account_truncating();
+	pub PeaqCoretimeAccount: AccountId = PotCoretimeId::get().into_account_truncating();
+	pub PeaqSubsidizationAccount: AccountId = PotSubsidizationId::get().into_account_truncating();
+	pub PeaqDepinStakingAccount: AccountId = PotDepinStakingId::get().into_account_truncating();
 }
 
 impl peaq_pallet_rbac::Config for Runtime {

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -704,6 +704,10 @@ parameter_types! {
 	pub const AssetAdminId: PalletId = PalletId(*b"AssetAdm");
 	pub const PotStakeId: PalletId = PalletId(*b"PotStake");
 	pub const PotTreasuryId: PalletId = TreasuryPalletId::get();
+	pub const PotCoretimeId: PalletId = PalletId(*b"PotCoret");
+	pub const PotSubsidizationId: PalletId = PalletId(*b"PotSubsi");
+	pub const PotDepinStakingId: PalletId = PalletId(*b"PotDPStk");
+	pub const PotDepinIncentivisationId: PalletId = PalletId(*b"PotDPInc");
 }
 
 impl pallet_authorship::Config for Runtime {
@@ -820,6 +824,10 @@ macro_rules! impl_to_pot_adapter {
 }
 
 impl_to_pot_adapter!(ToStakingPot, PotStakeId, NegativeImbalance);
+impl_to_pot_adapter!(ToCoreTimePot, PotCoretimeId, NegativeImbalance);
+impl_to_pot_adapter!(ToSubsidizationPot, PotSubsidizationId, NegativeImbalance);
+impl_to_pot_adapter!(ToDepinStakingPot, PotDepinStakingId, NegativeImbalance);
+impl_to_pot_adapter!(ToDepinIncentivizationPot, PotDepinIncentivisationId, NegativeImbalance);
 
 pub struct ToTreasuryPot;
 impl OnUnbalanced<NegativeImbalance> for ToTreasuryPot {
@@ -846,13 +854,21 @@ impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPa
 		ToStakingPot::on_unbalanced(reward);
 	}
 
-	fn coretime(_reward: NegativeImbalance) {}
+	fn coretime(reward: NegativeImbalance) {
+		ToCoreTimePot::on_unbalanced(reward);
+	}
 
-	fn subsidization_pool(_reward: NegativeImbalance) {}
+	fn subsidization_pool(reward: NegativeImbalance) {
+		ToSubsidizationPot::on_unbalanced(reward);
+	}
 
-	fn depin_incentivization(_reward: NegativeImbalance) {}
+	fn depin_staking(reward: NegativeImbalance) {
+		ToDepinStakingPot::on_unbalanced(reward);
+	}
 
-	fn depin_staking(_reward: NegativeImbalance) {}
+	fn depin_incentivization(reward: NegativeImbalance) {
+		ToDepinIncentivizationPot::on_unbalanced(reward);
+	}
 }
 
 parameter_types! {
@@ -863,6 +879,10 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
 	vec![
 		PotStakeId::get().into_account_truncating(),
 		PotTreasuryId::get().into_account_truncating(),
+		PotCoretimeId::get().into_account_truncating(),
+		PotSubsidizationId::get().into_account_truncating(),
+		PotDepinStakingId::get().into_account_truncating(),
+		PotDepinIncentivisationId::get().into_account_truncating(),
 	]
 }
 
@@ -877,6 +897,10 @@ parameter_types! {
 	pub PeaqAssetAdm: AccountId = AssetAdminId::get().into_account_truncating();
 	pub PeaqPotAccount: AccountId = PotStakeId::get().into_account_truncating();
 	pub PeaqTreasuryAccount: AccountId = TreasuryPalletId::get().into_account_truncating();
+	pub PeaqCoretimeAccount: AccountId = PotCoretimeId::get().into_account_truncating();
+	pub PeaqSubsidizationAccount: AccountId = PotSubsidizationId::get().into_account_truncating();
+	pub PeaqDepinStakingAccount: AccountId = PotDepinStakingId::get().into_account_truncating();
+	pub PeaqDepinIncentivisationAccount: AccountId = PotDepinIncentivisationId::get().into_account_truncating();
 }
 
 impl peaq_pallet_rbac::Config for Runtime {


### PR DESCRIPTION
This PR was created for this [task](https://app.asana.com/0/1201590612941071/1206726766332314).

The goal of this PR is to created the different pot in order to be able to split the rewards. 

Since only two pots were created for treasury and collators and those pots are remaining their code won't be impacted.
In the agung network some reward were going to the machines pots. The pot had been move under the `depin_incentivization` just for the agung network. For all the other network the machine pot won't be implemented. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206875183794511