### PR TITLE
readibility fix to inflation manager config and logic

### DIFF
--- a/pallets/inflation-manager/src/lib.rs
+++ b/pallets/inflation-manager/src/lib.rs
@@ -256,10 +256,10 @@ pub mod pallet {
 			let current_year = CurrentYear::<T>::get();
 
 			// Calculate disinflation rate as disinflation rate(n) = disinflation rate(0) ^ (n-1)
-			let disinflation_rate = inflation_config
-				.inflation_parameters
-				.disinflation_rate
-				.saturating_pow((current_year - 1).try_into().unwrap());
+			let disinflation = Perbill::from_percent(100) -
+				inflation_config.inflation_parameters.disinflation_rate;
+			let disinflation_rate =
+				disinflation.saturating_pow((current_year - 1).try_into().unwrap());
 
 			// Calculate effective inflation rate as
 			// inflation_rate(n) = inflation_rate(0) * disinflation_rate(n)

--- a/pallets/inflation-manager/src/mock.rs
+++ b/pallets/inflation-manager/src/mock.rs
@@ -107,7 +107,7 @@ parameter_types! {
 	pub const DefaultInflationConfiguration: types::InflationConfiguration = types::InflationConfiguration {
 		inflation_parameters: types::InflationParameters {
 			inflation_rate: Perbill::from_perthousand(35u32),
-			disinflation_rate: Perbill::from_percent(90),
+			disinflation_rate: Perbill::from_percent(10),
 		},
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,

--- a/pallets/inflation-manager/src/types.rs
+++ b/pallets/inflation-manager/src/types.rs
@@ -18,7 +18,7 @@ impl Default for InflationParameters {
 	fn default() -> Self {
 		Self {
 			inflation_rate: Perbill::from_perthousand(35u32),
-			disinflation_rate: Perbill::from_percent(90),
+			disinflation_rate: Perbill::from_percent(10),
 		}
 	}
 }

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -973,7 +973,7 @@ parameter_types! {
 	pub const DefaultInflationConfiguration: InflationConfiguration = InflationConfiguration {
 		inflation_parameters: InflationParameters {
 			inflation_rate: Perbill::from_perthousand(25u32),
-			disinflation_rate: Perbill::from_percent(90),
+			disinflation_rate: Perbill::from_percent(10),
 		},
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 10,

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -985,7 +985,7 @@ parameter_types! {
 	pub const DefaultInflationConfiguration: InflationConfiguration = InflationConfiguration {
 		inflation_parameters: InflationParameters {
 			inflation_rate: Perbill::from_perthousand(25u32),
-			disinflation_rate: Perbill::from_percent(90),
+			disinflation_rate: Perbill::from_percent(10),
 		},
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 10,

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -975,7 +975,7 @@ parameter_types! {
 	pub const DefaultInflationConfiguration: InflationConfiguration = InflationConfiguration {
 		inflation_parameters: InflationParameters {
 			inflation_rate: Perbill::from_perthousand(35u32),
-			disinflation_rate: Perbill::from_percent(90),
+			disinflation_rate: Perbill::from_percent(10),
 		},
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,


### PR DESCRIPTION
If Disinflation was 10%, we had to provide inflation manager disinflation as 90%. Fixed this so we can provide the correct amount.