### PR TITLE
Feat/1207389813143971 delayed tge for krest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "inflation-manager"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -159,6 +159,7 @@ parameter_types! {
 		inflation_stagnation_year: 13,
 	};
 	pub const InitializeInflationAt: BlockNumber = 0;
+	pub const BlockRewardBeforeInitialize: Balance = 0;
 }
 
 impl inflation_manager::Config for TestRuntime {
@@ -169,7 +170,8 @@ impl inflation_manager::Config for TestRuntime {
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type BoundedDataLen = ConstU32<1024>;
 	type WeightInfo = inflation_manager::weights::WeightInfo<TestRuntime>;
-	type DoRecalculationAt = InitializeInflationAt;
+	type DoInitializeAt = InitializeInflationAt;
+	type BlockRewardBeforeInitialize = BlockRewardBeforeInitialize;
 }
 
 impl pallet_block_reward::Config for TestRuntime {

--- a/pallets/block-reward/src/mock.rs
+++ b/pallets/block-reward/src/mock.rs
@@ -158,6 +158,7 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,
 	};
+	pub const InitializeInflationAt: BlockNumber = 0;
 }
 
 impl inflation_manager::Config for TestRuntime {
@@ -168,6 +169,7 @@ impl inflation_manager::Config for TestRuntime {
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type BoundedDataLen = ConstU32<1024>;
 	type WeightInfo = inflation_manager::weights::WeightInfo<TestRuntime>;
+	type DoRecalculationAt = InitializeInflationAt;
 }
 
 impl pallet_block_reward::Config for TestRuntime {

--- a/pallets/inflation-manager/Cargo.toml
+++ b/pallets/inflation-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inflation-manager"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/pallets/inflation-manager/src/lib.rs
+++ b/pallets/inflation-manager/src/lib.rs
@@ -168,15 +168,15 @@ pub mod pallet {
 		}
 
 		fn on_finalize(now: T::BlockNumber) {
-			let target_block = DoRecalculationAt::<T>::get();
-			let current_year = CurrentYear::<T>::get();
-			let new_year = current_year + 1;
-
-			let inflation_config = InflationConfiguration::<T>::get();
-			let mut inflation_parameters = InflationParameters::<T>::get();
-
 			// if we're at the end of a year or initializing inflation
+			let target_block = DoRecalculationAt::<T>::get();
 			if now == target_block {
+				let current_year = CurrentYear::<T>::get();
+				let new_year = current_year + 1;
+
+				let inflation_config = InflationConfiguration::<T>::get();
+				let mut inflation_parameters = InflationParameters::<T>::get();
+
 				// update current year
 				CurrentYear::<T>::put(new_year);
 

--- a/pallets/inflation-manager/src/lib.rs
+++ b/pallets/inflation-manager/src/lib.rs
@@ -185,22 +185,15 @@ pub mod pallet {
 					Self::fund_difference_balances();
 				}
 
-				// if we're not at the stagnation year, update inflation parameters
-				if new_year < inflation_config.inflation_stagnation_year {
-					// update inflation parameters
-					inflation_parameters = Self::update_inflation_parameters(&inflation_config);
-				}
-
 				// if we're at the stagnation year, set inflation parameters to the stagnation rate
 				if new_year == inflation_config.inflation_stagnation_year {
 					inflation_parameters = InflationParametersT {
 						inflation_rate: inflation_config.inflation_stagnation_rate,
 						disinflation_rate: Perbill::one(),
 					};
-				}
-
-				// no need to update InflationParameters in storage after inflation stagnation year
-				if current_year <= inflation_config.inflation_stagnation_year {
+					InflationParameters::<T>::put(inflation_parameters.clone());
+				} else if new_year < inflation_config.inflation_stagnation_year {
+					inflation_parameters = Self::update_inflation_parameters(&inflation_config);
 					InflationParameters::<T>::put(inflation_parameters.clone());
 				}
 

--- a/pallets/inflation-manager/src/lib.rs
+++ b/pallets/inflation-manager/src/lib.rs
@@ -151,7 +151,6 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			let inflation_configuration = T::DefaultInflationConfiguration::get();
 			let do_recalculation_at = T::DoRecalculationAt::get();
 
 			// if DoRecalculationAt was provided as zero,

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -11,6 +11,8 @@ mod upgrade {
 
 	pub struct MigrateToV0<T>(sp_std::marker::PhantomData<T>);
 
+	// This migration will trigger for krest runtime, but not peaq runtime
+	// since peaq will have already been migrated to this storage version with pallet version 0.1.0
 	impl<T: Config> MigrateToV0<T> {
 		pub fn on_runtime_upgrade() -> Weight {
 			let mut weight_writes = 0;

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -1,7 +1,6 @@
 use super::*;
 
 use frame_support::{pallet_prelude::*, weights::Weight};
-use sp_runtime::traits::AccountIdConversion;
 
 pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
 	upgrade::MigrateToV0::<T>::on_runtime_upgrade()
@@ -13,75 +12,46 @@ mod upgrade {
 	pub struct MigrateToV0<T>(sp_std::marker::PhantomData<T>);
 
 	impl<T: Config> MigrateToV0<T> {
-		fn fund_difference_balances() {
-			let account = T::PotId::get().into_account_truncating();
-			let now_total_issuance = T::Currency::total_issuance();
-			let desired_issuance = T::DefaultTotalIssuanceNum::get();
-			if now_total_issuance < desired_issuance {
-				let amount = desired_issuance.saturating_sub(now_total_issuance);
-				T::Currency::deposit_creating(&account, amount);
-				log::info!(
-					"Total issuance was increased from {:?} to {:?}, by {:?} tokens.",
-					now_total_issuance,
-					desired_issuance,
-					amount
-				);
-			}
-		}
-
 		pub fn on_runtime_upgrade() -> Weight {
 			let mut weight_writes = 0;
 			let mut weight_reads = 0;
+			let mut calculated_weight: Weight = 0.into();
 
+			// get storage versions
 			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();
 			weight_reads += 1;
-
 			let current = Pallet::<T>::current_storage_version();
 
 			if onchain_storage_version < current {
-				Self::fund_difference_balances();
+				let do_recalculation_at = T::DoRecalculationAt::get();
 
-				let inflation_configuration = T::DefaultInflationConfiguration::get();
-				// install inflation config
-				InflationConfiguration::<T>::put(inflation_configuration.clone());
-				weight_writes += 1;
-
-				// set current year to 1
-				CurrentYear::<T>::put(1);
-				weight_writes += 1;
-
-				// calculate inflation parameters for the first year
-				let inflation_parameters =
-					Pallet::<T>::update_inflation_parameters(&inflation_configuration);
+				let current_block = frame_system::Pallet::<T>::current_block_number();
 				weight_reads += 1;
 
-				// install inflation parameters for first year
-				InflationParameters::<T>::put(inflation_parameters.clone());
-				weight_writes += 1;
+				// If Config::DoRecalculationAt was 0, then kick off inflation year 1 with TGE
+				if do_recalculation_at == T::BlockNumber::from(0u32) {
+					// adjust total issuance for TGE
+					Pallet::<T>::fund_difference_balances();
+					calculated_weight = Pallet::<T>::initialize_inflation();
 
-				// set the flag to calculate inflation parameters after a year(in blocks)
-				let racalculation_target_block = frame_system::Pallet::<T>::current_block_number() +
-					T::BlockNumber::from(BLOCKS_PER_YEAR);
-				weight_reads += 1;
-
-				// Update recalculation flag
-				DoRecalculationAt::<T>::put(racalculation_target_block);
-				weight_writes += 1;
-
-				let block_rewards = Pallet::<T>::rewards_per_block(&inflation_parameters);
-				weight_reads += 1;
-
-				BlockRewards::<T>::put(block_rewards);
-				weight_writes += 1;
+					log::info!(
+						"Inflation Manager storage migration completed from version {:?} to version {:?} with TGE", onchain_storage_version, current
+					);
+				} else if do_recalculation_at > current_block {
+					calculated_weight =
+						Pallet::<T>::initialize_delayed_inflation(do_recalculation_at);
+				}
 
 				// Update storage version
 				STORAGE_VERSION.put::<Pallet<T>>();
+				weight_writes += 1;
 
 				log::info!(
 					"Inflation Manager storage migration completed from version {:?} to version {:?}", onchain_storage_version, current
 				);
 			}
-			T::DbWeight::get().reads_writes(weight_reads, weight_writes)
+			calculated_weight
+				.saturating_add(T::DbWeight::get().reads_writes(weight_reads, weight_writes))
 		}
 	}
 }

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -23,13 +23,13 @@ mod upgrade {
 			let current = Pallet::<T>::current_storage_version();
 
 			if onchain_storage_version < current {
-				let do_recalculation_at = T::DoRecalculationAt::get();
+				let do_initialize_at = T::DoInitializeAt::get();
 
 				let current_block = frame_system::Pallet::<T>::current_block_number();
 				weight_reads += 1;
 
 				// If Config::DoRecalculationAt was 0, then kick off inflation year 1 with TGE
-				if do_recalculation_at == T::BlockNumber::from(0u32) {
+				if do_initialize_at == T::BlockNumber::from(0u32) {
 					// adjust total issuance for TGE
 					Pallet::<T>::fund_difference_balances();
 					calculated_weight = Pallet::<T>::initialize_inflation();
@@ -37,9 +37,8 @@ mod upgrade {
 					log::info!(
 						"Inflation Manager storage migration completed from version {:?} to version {:?} with TGE", onchain_storage_version, current
 					);
-				} else if do_recalculation_at > current_block {
-					calculated_weight =
-						Pallet::<T>::initialize_delayed_inflation(do_recalculation_at);
+				} else if do_initialize_at > current_block {
+					calculated_weight = Pallet::<T>::initialize_delayed_inflation(do_initialize_at);
 				}
 
 				// Update storage version

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -15,7 +15,7 @@ mod upgrade {
 		pub fn on_runtime_upgrade() -> Weight {
 			let mut weight_writes = 0;
 			let mut weight_reads = 0;
-			let mut calculated_weight: Weight = 0.into();
+			let mut calculated_weight: Weight = Weight::default();
 
 			// get storage versions
 			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();

--- a/pallets/inflation-manager/src/mock.rs
+++ b/pallets/inflation-manager/src/mock.rs
@@ -113,6 +113,7 @@ parameter_types! {
 		inflation_stagnation_year: 13,
 	};
 	pub const InitializeInflationAt: BlockNumber = 0;
+	pub const BlockRewardBeforeInitialize: Balance = 0;
 }
 
 impl inflation_manager::Config for TestRuntime {
@@ -123,7 +124,8 @@ impl inflation_manager::Config for TestRuntime {
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type BoundedDataLen = ConstU32<1024>;
 	type WeightInfo = weights::WeightInfo<TestRuntime>;
-	type DoRecalculationAt = InitializeInflationAt;
+	type DoInitializeAt = InitializeInflationAt;
+	type BlockRewardBeforeInitialize = BlockRewardBeforeInitialize;
 }
 pub struct ExternalityBuilder {
 	// endowed accounts with balances

--- a/pallets/inflation-manager/src/mock.rs
+++ b/pallets/inflation-manager/src/mock.rs
@@ -112,8 +112,8 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,
 	};
-	pub const InitializeInflationAt: BlockNumber = 0;
-	pub const BlockRewardBeforeInitialize: Balance = 0;
+	pub const InitializeInflationAt: BlockNumber = 10;
+	pub const BlockRewardBeforeInitialize: Balance = 1000;
 }
 
 impl inflation_manager::Config for TestRuntime {

--- a/pallets/inflation-manager/src/mock.rs
+++ b/pallets/inflation-manager/src/mock.rs
@@ -112,6 +112,7 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,
 	};
+	pub const InitializeInflationAt: BlockNumber = 0;
 }
 
 impl inflation_manager::Config for TestRuntime {
@@ -122,6 +123,7 @@ impl inflation_manager::Config for TestRuntime {
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type BoundedDataLen = ConstU32<1024>;
 	type WeightInfo = weights::WeightInfo<TestRuntime>;
+	type DoRecalculationAt = InitializeInflationAt;
 }
 pub struct ExternalityBuilder {
 	// endowed accounts with balances

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -135,6 +135,13 @@ fn stagnation_reached_as_expected() {
 			.map(|i| InflationManagerSnapshot::take_snapshot_at(BLOCKS_PER_YEAR * i as u32))
 			.collect();
 
+		for snapsot in yearly_snapshots.iter() {
+			println!(
+				"year: {}, inflation_parameters: {:?}",
+				snapsot.current_year,
+				snapsot.inflation_parameters
+			);
+		}
 		// verify snapshot inflation parameters - stagnation year index is (year - 1)
 		assert_eq!(
 			yearly_snapshots[stagnation_snapshot_year - 1]

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -135,13 +135,6 @@ fn stagnation_reached_as_expected() {
 			.map(|i| InflationManagerSnapshot::take_snapshot_at(BLOCKS_PER_YEAR * i as u32))
 			.collect();
 
-		for snapsot in yearly_snapshots.iter() {
-			println!(
-				"year: {}, inflation_parameters: {:?}",
-				snapsot.current_year,
-				snapsot.inflation_parameters
-			);
-		}
 		// verify snapshot inflation parameters - stagnation year index is (year - 1)
 		assert_eq!(
 			yearly_snapshots[stagnation_snapshot_year - 1]
@@ -193,6 +186,15 @@ fn inflation_parameters_correctness_as_expected() {
 			);
 		}
 	})
+}
+
+#[test]
+fn check_block_issue_rewards(){
+	ExternalityBuilder::default().build().execute_with(|| {
+		let bir = BlockIssueReward::get();
+		println!("bir: {:?}", bir);
+	})
+
 }
 /// Represents inflation manager storage snapshot at current block
 #[derive(PartialEq, Eq, Clone, RuntimeDebug)]

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -188,14 +188,6 @@ fn inflation_parameters_correctness_as_expected() {
 	})
 }
 
-#[test]
-fn check_block_issue_rewards(){
-	ExternalityBuilder::default().build().execute_with(|| {
-		let bir = BlockIssueReward::get();
-		println!("bir: {:?}", bir);
-	})
-
-}
 /// Represents inflation manager storage snapshot at current block
 #[derive(PartialEq, Eq, Clone, RuntimeDebug)]
 struct InflationManagerSnapshot {

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -9,28 +9,38 @@ use sp_runtime::{
 };
 
 #[test]
-fn sanity_check_genesis() {
+fn sanity_check_genesis_delayed_tge() {
 	ExternalityBuilder::default().build().execute_with(|| {
 		let snapshot = InflationManagerSnapshot::take_snapshot_at(0);
-		let expected_inflation_parameters = InflationParametersT {
-			inflation_rate: Perbill::from_perthousand(35u32),
-			disinflation_rate: Perbill::one(),
-		};
+		// Delayed TGE sets inflation parameters as their default falue
+		let expected_inflation_parameters = InflationParametersT::default();
 
 		assert_eq!(snapshot.inflation_configuration, InflationConfigurationT::default());
 		assert_eq!(snapshot.inflation_parameters, expected_inflation_parameters);
-		assert_eq!(snapshot.do_recalculation_at, BLOCKS_PER_YEAR);
-		assert_eq!(snapshot.current_year, 1u128);
+		assert_eq!(
+			snapshot.do_recalculation_at as u64,
+			<TestRuntime as Config>::DoInitializeAt::get()
+		);
+		// inflation has not kicked off, so current year should be 0
+		assert_eq!(snapshot.current_year, 0u128);
+		assert_eq!(
+			snapshot.block_rewards,
+			<TestRuntime as Config>::BlockRewardBeforeInitialize::get()
+		);
 	})
 }
 
 #[test]
-fn check_fund_enough_token() {
+fn check_fund_enough_token_at_delayed_tge_kickoff() {
 	ExternalityBuilder::default()
 		.with_balances(vec![(1, 20)])
 		.build()
 		.execute_with(|| {
-			InflationManager::on_runtime_upgrade();
+			let do_initialize_at = <TestRuntime as Config>::DoInitializeAt::get();
+			// set current block to DoInitializeAt
+			System::set_block_number(do_initialize_at);
+			// run on_finalize
+			InflationManager::on_finalize(do_initialize_at.into());
 
 			assert_eq!(
 				<TestRuntime as Config>::Currency::total_issuance(),
@@ -52,12 +62,16 @@ fn check_fund_enough_token() {
 }
 
 #[test]
-fn check_not_fund_token() {
+fn check_not_fund_token_at_delayed_tge_kickoff() {
 	ExternalityBuilder::default()
 		.with_balances(vec![(1, DefaultTotalIssuanceNum::get() + 50)])
 		.build()
 		.execute_with(|| {
-			InflationManager::on_runtime_upgrade();
+			let do_initialize_at = <TestRuntime as Config>::DoInitializeAt::get();
+			// set current block to DoInitializeAt
+			System::set_block_number(do_initialize_at);
+			// run on_finalize
+			InflationManager::on_finalize(do_initialize_at.into());
 
 			assert_eq!(
 				<TestRuntime as Config>::Currency::total_issuance(),
@@ -67,72 +81,87 @@ fn check_not_fund_token() {
 }
 
 #[test]
-fn sanity_check_storage_migration() {
+fn sanity_check_storage_migration_for_delayed_tge() {
 	ExternalityBuilder::default().build().execute_with(|| {
 		InflationManager::on_runtime_upgrade();
 		let current_block = System::block_number() as u32;
 
+		let total_issuance_before_upgrade = <TestRuntime as Config>::Currency::total_issuance();
+		// Delayed TGE is set so this should have no affect
+		InflationManager::on_runtime_upgrade();
 		let snapshot = InflationManagerSnapshot::take_snapshot_at(current_block);
-		let expected_inflation_parameters = InflationParametersT {
-			inflation_rate: Perbill::from_perthousand(35u32),
-			disinflation_rate: Perbill::one(),
-		};
+		// Delayed TGE sets inflation parameters as their default value
+		let expected_inflation_parameters = InflationParametersT::default();
 
+		assert_eq!(
+			total_issuance_before_upgrade,
+			<TestRuntime as Config>::Currency::total_issuance()
+		);
 		assert_eq!(snapshot.inflation_configuration, InflationConfigurationT::default());
 		assert_eq!(snapshot.inflation_parameters, expected_inflation_parameters);
-		assert_eq!(snapshot.do_recalculation_at, BLOCKS_PER_YEAR + current_block);
-		assert_eq!(snapshot.current_year, 1u128);
+		assert_eq!(
+			snapshot.do_recalculation_at as u64,
+			<TestRuntime as Config>::DoInitializeAt::get()
+		);
+		assert_eq!(snapshot.current_year, 0u128);
+		assert_eq!(
+			snapshot.block_rewards,
+			<TestRuntime as Config>::BlockRewardBeforeInitialize::get()
+		);
 	})
 }
 
 // In the DoRecalculationAt block,
 // Block rewards are distributed first and then block rewards are updated
 #[test]
-fn parameters_update_as_expected() {
+fn parameters_update_as_expected_at_tge() {
 	ExternalityBuilder::default().build().execute_with(|| {
-		let target_block_at_genesis = BLOCKS_PER_YEAR;
+		let do_initialize_at = <TestRuntime as Config>::DoInitializeAt::get() as u32;
+		let target_block_at_genesis = do_initialize_at;
 
-		let snapshots_before_new_year = vec![
+		let snapshots_before_tge = vec![
 			InflationManagerSnapshot::take_snapshot_at(target_block_at_genesis - 2),
 			InflationManagerSnapshot::take_snapshot_at(target_block_at_genesis - 1),
 		];
 
-		let snapshots_after_new_year = vec![
+		let snapshots_after_tge = vec![
 			InflationManagerSnapshot::take_snapshot_at(target_block_at_genesis),
 			InflationManagerSnapshot::take_snapshot_at(target_block_at_genesis + 1),
 		];
 
-		// Check that the snapshots before the new year are consistent
-		assert_eq!(snapshots_before_new_year[0], snapshots_before_new_year[1]);
+		// Check that the snapshots before the TGE are consistent
+		assert_eq!(snapshots_before_tge[0], snapshots_before_tge[1]);
 
-		// check that the snapshots after the new year are consistent
-		assert_eq!(snapshots_after_new_year[0], snapshots_after_new_year[1]);
+		// check that the snapshots after the TGE are consistent
+		assert_eq!(snapshots_after_tge[0], snapshots_after_tge[1]);
 
 		// check that the snapshots before and after the new year are different
-		assert_ne!(snapshots_before_new_year[1], snapshots_after_new_year[0]);
+		assert_ne!(snapshots_before_tge[1], snapshots_after_tge[0]);
 
-		// check that the snapshots after the new year are consistent with the expected values
-		assert_eq!(snapshots_after_new_year[0].current_year, 2);
+		// check that the snapshots after the TGE are consistent with the expected values
+		assert_eq!(snapshots_after_tge[0].current_year, 1);
 		assert_eq!(
-			snapshots_after_new_year[0].do_recalculation_at,
-			snapshots_before_new_year[0].do_recalculation_at + BLOCKS_PER_YEAR
+			snapshots_after_tge[0].do_recalculation_at,
+			snapshots_before_tge[0].do_recalculation_at + BLOCKS_PER_YEAR
 		);
-		assert_ne!(
-			snapshots_after_new_year[0].block_rewards,
-			snapshots_before_new_year[0].block_rewards
-		);
+		assert_ne!(snapshots_after_tge[0].block_rewards, snapshots_before_tge[0].block_rewards);
 	})
 }
 
 #[test]
-fn stagnation_reached_as_expected() {
+fn stagnation_reached_as_expected_with_delayed_tge() {
 	ExternalityBuilder::default().build().execute_with(|| {
 		let inflation_configuration = InflationManager::inflation_configuration();
 		let stagnation_snapshot_year = inflation_configuration.inflation_stagnation_year as usize;
 		let last_snapshot_year = stagnation_snapshot_year + 1;
+		let do_recalculation_at = InflationManager::do_recalculation_at() as u32;
 
 		let yearly_snapshots: Vec<InflationManagerSnapshot> = (0..=last_snapshot_year)
-			.map(|i| InflationManagerSnapshot::take_snapshot_at(BLOCKS_PER_YEAR * i as u32))
+			.map(|i| {
+				InflationManagerSnapshot::take_snapshot_at(
+					do_recalculation_at + (BLOCKS_PER_YEAR * i as u32),
+				)
+			})
 			.collect();
 
 		// verify snapshot inflation parameters - stagnation year index is (year - 1)
@@ -165,9 +194,24 @@ fn inflation_parameters_correctness_as_expected() {
 			Perbill::one() - inflation_configuration.inflation_parameters.disinflation_rate;
 		let inflation = inflation_configuration.inflation_parameters.inflation_rate;
 		let mut expected_yearly_inflation_parameters: Vec<InflationParametersT> = vec![];
+		let do_recalculation_at = InflationManager::do_recalculation_at() as u32;
+
+		// verify correct parameters before TGE
+		let snapshot_before_tge =
+			InflationManagerSnapshot::take_snapshot_at(do_recalculation_at - 1);
+		assert_eq!(snapshot_before_tge.inflation_parameters, InflationParametersT::default());
+		assert_eq!(snapshot_before_tge.current_year, 0);
+		assert_eq!(
+			snapshot_before_tge.do_recalculation_at as u64,
+			<TestRuntime as Config>::DoInitializeAt::get()
+		);
 
 		let yearly_snapshots: Vec<InflationManagerSnapshot> = (0..last_snapshot_year)
-			.map(|i| InflationManagerSnapshot::take_snapshot_at(BLOCKS_PER_YEAR * i as u32))
+			.map(|i| {
+				InflationManagerSnapshot::take_snapshot_at(
+					do_recalculation_at + (BLOCKS_PER_YEAR * i as u32),
+				)
+			})
 			.collect();
 
 		for i in 0..last_snapshot_year {

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -40,7 +40,7 @@ fn check_fund_enough_token_at_delayed_tge_kickoff() {
 			// set current block to DoInitializeAt
 			System::set_block_number(do_initialize_at);
 			// run on_finalize
-			InflationManager::on_finalize(do_initialize_at.into());
+			InflationManager::on_finalize(do_initialize_at);
 
 			assert_eq!(
 				<TestRuntime as Config>::Currency::total_issuance(),
@@ -71,7 +71,7 @@ fn check_not_fund_token_at_delayed_tge_kickoff() {
 			// set current block to DoInitializeAt
 			System::set_block_number(do_initialize_at);
 			// run on_finalize
-			InflationManager::on_finalize(do_initialize_at.into());
+			InflationManager::on_finalize(do_initialize_at);
 
 			assert_eq!(
 				<TestRuntime as Config>::Currency::total_issuance(),

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -987,6 +987,7 @@ parameter_types! {
 		inflation_stagnation_year: 10,
 	};
 	pub const InitializeInflationAt: BlockNumber = 0;
+	pub const BlockRewardBeforeInitialize: Balance = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -997,7 +998,8 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
-	type DoRecalculationAt = InitializeInflationAt;
+	type DoInitializeAt = InitializeInflationAt;
+	type BlockRewardBeforeInitialize = BlockRewardBeforeInitialize;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/krest/src/lib.rs
+++ b/runtime/krest/src/lib.rs
@@ -986,6 +986,7 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 10,
 	};
+	pub const InitializeInflationAt: BlockNumber = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -996,6 +997,7 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
+	type DoRecalculationAt = InitializeInflationAt;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -1000,6 +1000,7 @@ parameter_types! {
 		inflation_stagnation_year: 10,
 	};
 	pub const InitializeInflationAt: BlockNumber = 0;
+	pub const BlockRewardBeforeInitialize: Balance = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -1010,7 +1011,8 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
-	type DoRecalculationAt = InitializeInflationAt;
+	type DoInitializeAt = InitializeInflationAt;
+	type BlockRewardBeforeInitialize = BlockRewardBeforeInitialize;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -999,6 +999,7 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 10,
 	};
+	pub const InitializeInflationAt: BlockNumber = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -1009,6 +1010,7 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
+	type DoRecalculationAt = InitializeInflationAt;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -985,6 +985,7 @@ parameter_types! {
 		inflation_stagnation_rate: Perbill::from_percent(1),
 		inflation_stagnation_year: 13,
 	};
+	pub const InitializeInflationAt: BlockNumber = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -995,6 +996,7 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
+	type DoRecalculationAt = InitializeInflationAt;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -986,6 +986,7 @@ parameter_types! {
 		inflation_stagnation_year: 13,
 	};
 	pub const InitializeInflationAt: BlockNumber = 0;
+	pub const BlockRewardBeforeInitialize: Balance = 0;
 }
 
 impl inflation_manager::Config for Runtime {
@@ -996,7 +997,8 @@ impl inflation_manager::Config for Runtime {
 	type DefaultTotalIssuanceNum = DefaultTotalIssuanceNum;
 	type DefaultInflationConfiguration = DefaultInflationConfiguration;
 	type WeightInfo = inflation_manager::weights::WeightInfo<Runtime>;
-	type DoRecalculationAt = InitializeInflationAt;
+	type DoInitializeAt = InitializeInflationAt;
+	type BlockRewardBeforeInitialize = BlockRewardBeforeInitialize;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
- As two pallets are tightly coupled due to requirements provided at the time of it's implementation, to implemente TGE, we do not kill pallet-block-rewards::BlockIssueRewards, and continue issuing these conditionally until delayed TGE is reached.

Look at attached asana task for more details.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207389813143971