### PR TITLE
Revert XCM fee first

### DIFF
--- a/runtime/common/src/xcm_impls.rs
+++ b/runtime/common/src/xcm_impls.rs
@@ -3,10 +3,10 @@ use sp_std::marker::PhantomData;
 use xc_asset_config::ExecutionPaymentRate;
 use xcm::latest::{
 	prelude::{Fungibility, MultiAsset, MultiLocation, XcmError},
-	MultiAssets, Weight,
+	Weight,
 };
 use xcm_builder::TakeRevenue;
-use xcm_executor::traits::{FeeManager, FeeReason, WeightTrader};
+use xcm_executor::traits::WeightTrader;
 
 /// Used as weight trader for foreign assets.
 ///
@@ -118,12 +118,4 @@ impl<T: ExecutionPaymentRate, R: TakeRevenue> Drop for FixedRateOfForeignAsset<T
 			}
 		}
 	}
-}
-
-pub struct FeeManagerNotWaived;
-impl FeeManager for FeeManagerNotWaived {
-	fn is_waived(_: Option<&MultiLocation>, _: FeeReason) -> bool {
-		false
-	}
-	fn handle_fee(_: MultiAssets) {}
 }

--- a/runtime/krest/src/xcm_config.rs
+++ b/runtime/krest/src/xcm_config.rs
@@ -3,8 +3,6 @@ use super::{
 	ParachainInfo, ParachainSystem, PeaqPotAccount, PolkadotXcm, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, StorageAssetId, WeightToFee, XcAssetConfig, XcmpQueue,
 };
-use cumulus_pallet_xcmp_queue::PriceForSiblingDelivery;
-use cumulus_primitives_core::ParaId;
 use frame_support::{
 	dispatch::Weight,
 	match_types, parameter_types,
@@ -15,7 +13,7 @@ use orml_traits::location::{RelativeReserveProvider, Reserve};
 use orml_xcm_support::DisabledParachainFee;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use runtime_common::{AccountIdToMultiLocation, FeeManagerNotWaived, FixedRateOfForeignAsset};
+use runtime_common::{AccountIdToMultiLocation, FixedRateOfForeignAsset};
 use sp_runtime::traits::ConstU32;
 use xc_asset_config::MultiLocationToAssetId;
 use xcm::latest::{prelude::*, MultiAsset};
@@ -48,7 +46,6 @@ use xcm_builder::{
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
 use frame_support::pallet_prelude::Get;
-use parity_scale_codec::Encode;
 use sp_runtime::traits::Zero;
 use sp_std::marker::PhantomData;
 use xcm_executor::traits::MatchesFungibles;
@@ -272,7 +269,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = ConstU32<64>;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = FeeManagerNotWaived;
+	type FeeManager = ();
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = Everything;
@@ -330,22 +327,6 @@ impl cumulus_pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 }
 
-pub struct ExponentialFee;
-
-impl ExponentialFee {
-	fn calculate_fee(size: usize) -> MultiAssets {
-		let fee = (size * size) as u16;
-		MultiAssets::from((Here, fee))
-	}
-}
-
-impl PriceForSiblingDelivery for ExponentialFee {
-	fn price_for_sibling_delivery(_: ParaId, message: &Xcm<()>) -> MultiAssets {
-		let size = message.using_encoded(|encoded| encoded.len());
-		Self::calculate_fee(size)
-	}
-}
-
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -355,7 +336,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ControllerOrigin = EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToCallOrigin;
 	type WeightInfo = ();
-	type PriceForSiblingDelivery = ExponentialFee;
+	type PriceForSiblingDelivery = ();
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {

--- a/runtime/peaq-dev/src/xcm_config.rs
+++ b/runtime/peaq-dev/src/xcm_config.rs
@@ -3,8 +3,6 @@ use super::{
 	ParachainInfo, ParachainSystem, PeaqPotAccount, PolkadotXcm, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, StorageAssetId, WeightToFee, XcAssetConfig, XcmpQueue,
 };
-use cumulus_pallet_xcmp_queue::PriceForSiblingDelivery;
-use cumulus_primitives_core::ParaId;
 use frame_support::{
 	dispatch::Weight,
 	match_types, parameter_types,
@@ -15,7 +13,7 @@ use orml_traits::location::{RelativeReserveProvider, Reserve};
 use orml_xcm_support::DisabledParachainFee;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use runtime_common::{AccountIdToMultiLocation, FeeManagerNotWaived, FixedRateOfForeignAsset};
+use runtime_common::{AccountIdToMultiLocation, FixedRateOfForeignAsset};
 use sp_runtime::traits::ConstU32;
 use xc_asset_config::MultiLocationToAssetId;
 use xcm::latest::{prelude::*, MultiAsset};
@@ -48,7 +46,6 @@ use xcm_builder::{
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
 use frame_support::pallet_prelude::Get;
-use parity_scale_codec::Encode;
 use sp_runtime::traits::Zero;
 use sp_std::marker::PhantomData;
 use xcm_executor::traits::MatchesFungibles;
@@ -272,7 +269,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = ConstU32<64>;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = FeeManagerNotWaived;
+	type FeeManager = ();
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = Everything;
@@ -330,22 +327,6 @@ impl cumulus_pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 }
 
-pub struct ExponentialFee;
-
-impl ExponentialFee {
-	fn calculate_fee(size: usize) -> MultiAssets {
-		let fee = (size * size) as u16;
-		MultiAssets::from((Here, fee))
-	}
-}
-
-impl PriceForSiblingDelivery for ExponentialFee {
-	fn price_for_sibling_delivery(_: ParaId, message: &Xcm<()>) -> MultiAssets {
-		let size = message.using_encoded(|encoded| encoded.len());
-		Self::calculate_fee(size)
-	}
-}
-
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -355,7 +336,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ControllerOrigin = EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToCallOrigin;
 	type WeightInfo = ();
-	type PriceForSiblingDelivery = ExponentialFee;
+	type PriceForSiblingDelivery = ();
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {

--- a/runtime/peaq/src/xcm_config.rs
+++ b/runtime/peaq/src/xcm_config.rs
@@ -3,8 +3,6 @@ use super::{
 	ParachainInfo, ParachainSystem, PeaqPotAccount, PolkadotXcm, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, StorageAssetId, WeightToFee, XcAssetConfig, XcmpQueue,
 };
-use cumulus_pallet_xcmp_queue::PriceForSiblingDelivery;
-use cumulus_primitives_core::ParaId;
 use frame_support::{
 	dispatch::Weight,
 	match_types, parameter_types,
@@ -15,7 +13,7 @@ use orml_traits::location::{RelativeReserveProvider, Reserve};
 use orml_xcm_support::DisabledParachainFee;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use runtime_common::{AccountIdToMultiLocation, FeeManagerNotWaived, FixedRateOfForeignAsset};
+use runtime_common::{AccountIdToMultiLocation, FixedRateOfForeignAsset};
 use sp_runtime::traits::ConstU32;
 use xc_asset_config::MultiLocationToAssetId;
 use xcm::latest::{prelude::*, MultiAsset};
@@ -48,7 +46,6 @@ use xcm_builder::{
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
 use frame_support::pallet_prelude::Get;
-use parity_scale_codec::Encode;
 use sp_runtime::traits::Zero;
 use sp_std::marker::PhantomData;
 use xcm_executor::traits::MatchesFungibles;
@@ -272,7 +269,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = ConstU32<64>;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = FeeManagerNotWaived;
+	type FeeManager = ();
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type SafeCallFilter = Everything;
@@ -330,22 +327,6 @@ impl cumulus_pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 }
 
-pub struct ExponentialFee;
-
-impl ExponentialFee {
-	fn calculate_fee(size: usize) -> MultiAssets {
-		let fee = (size * size) as u16;
-		MultiAssets::from((Here, fee))
-	}
-}
-
-impl PriceForSiblingDelivery for ExponentialFee {
-	fn price_for_sibling_delivery(_: ParaId, message: &Xcm<()>) -> MultiAssets {
-		let size = message.using_encoded(|encoded| encoded.len());
-		Self::calculate_fee(size)
-	}
-}
-
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -355,7 +336,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type ControllerOrigin = EnsureRoot<AccountId>;
 	type ControllerOriginConverter = XcmOriginToCallOrigin;
 	type WeightInfo = ();
-	type PriceForSiblingDelivery = ExponentialFee;
+	type PriceForSiblingDelivery = ();
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {


### PR DESCRIPTION
XTokens.transfer fails when our native currency is used from one chain to another. Therefore, revert it first to satisfy the integration test and continue to survey