### PR TITLE
Merge the revert of Agung's ED again

### DIFF
--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -395,7 +395,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = DOLLARS;
+	pub const ExistentialDeposit: u128 = 500;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxReserves: u32 = 50;
 	pub const DIDReserveIdentifier: [u8; 8] = [b'p', b'e', b'a', b'q', b'_', b'd', b'i', b'd'];


### PR DESCRIPTION
Found out that in the dev branch, because of the bug/1207494781201042_code_improve merge, it overrides this merge unexpected
```
f7cd9936 Merge pull request #255 from peaqnetwork/fix/1207452617113212_change-ED
```

The reason is that below two comments are cherry-picked from bug/1207494781201042_code_improve
```
2df7e52d fix(): Change ExistentialDeposit in order to avoid bloat attacks
c070d6b5 fix(): Change ExistentialDeposit to 1 instead of 0.5
```