### PR TITLE
Feat/1208111230419859 migrate inflation mgr vesting

### DIFF
--- a/pallets/inflation-manager/src/lib.rs
+++ b/pallets/inflation-manager/src/lib.rs
@@ -36,7 +36,7 @@ use sp_runtime::{traits::BlockNumberProvider, Perbill};
 use sp_std::cmp::Ordering;
 
 pub const BLOCKS_PER_YEAR: peaq_primitives_xcm::BlockNumber = 365 * 24 * 60 * 60 / 6_u32;
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -1,20 +1,21 @@
 use super::*;
 
 use frame_support::{pallet_prelude::*, weights::Weight};
+use sp_runtime::Saturating;
 
 pub(crate) fn on_runtime_upgrade<T: Config>() -> Weight {
-	upgrade::MigrateToV0::<T>::on_runtime_upgrade()
+	upgrade::MigrateToV2::<T>::on_runtime_upgrade()
 }
 
 mod upgrade {
 	use super::*;
 
-	pub struct MigrateToV0<T>(sp_std::marker::PhantomData<T>);
+	pub struct MigrateToV2<T>(sp_std::marker::PhantomData<T>);
 
 	// This migration will trigger for krest runtime, but not peaq runtime
 	// since peaq will have already been migrated to this storage version with pallet version 0.1.0
-	impl<T: Config> MigrateToV0<T> {
-		pub fn on_runtime_upgrade() -> Weight {
+	impl<T: Config> MigrateToV2<T> {
+		fn migrate_to_v1() -> Weight {
 			let mut weight_writes = 0;
 			let mut weight_reads = 0;
 			let mut calculated_weight: Weight = Weight::default();
@@ -22,9 +23,9 @@ mod upgrade {
 			// get storage versions
 			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();
 			weight_reads += 1;
-			let current = Pallet::<T>::current_storage_version();
+			const STORAGE_V1: StorageVersion = StorageVersion::new(1);
 
-			if onchain_storage_version < current {
+			if onchain_storage_version < STORAGE_V1 {
 				let do_initialize_at = T::DoInitializeAt::get();
 				DoInitializeAt::<T>::put(do_initialize_at);
 				TotalIssuanceNum::<T>::put(T::DefaultTotalIssuanceNum::get());
@@ -41,11 +42,73 @@ mod upgrade {
 					calculated_weight = Pallet::<T>::initialize_inflation();
 
 					log::info!(
-						"Inflation Manager storage migration completed from version {:?} to version {:?} with TGE", onchain_storage_version, current
+						"Inflation Manager storage migration completed from version {:?} to version {:?} with TGE", onchain_storage_version, STORAGE_V1
 					);
 				} else if do_initialize_at > current_block {
 					calculated_weight = Pallet::<T>::initialize_delayed_inflation(do_initialize_at);
 				}
+
+				// Update storage version
+				STORAGE_V1.put::<Pallet<T>>();
+				weight_writes += 1;
+
+				log::info!(
+					"Inflation Manager storage migration completed from version {:?} to version {:?}", onchain_storage_version, STORAGE_V1
+				);
+			}
+			calculated_weight
+				.saturating_add(T::DbWeight::get().reads_writes(weight_reads, weight_writes))
+		}
+
+		fn migrate_to_v2() -> Weight {
+			let mut weight_writes = 0;
+			let mut weight_reads = 0;
+			let calculated_weight: Weight = Weight::default();
+
+			// get storage versions
+			let onchain_storage_version = Pallet::<T>::on_chain_storage_version();
+			weight_reads += 1;
+			// That should be 2
+			let current = Pallet::<T>::current_storage_version();
+
+			if onchain_storage_version < current {
+				// Just keep the total issuance number consistent if it is not set
+				if TotalIssuanceNum::<T>::get() == 0 {
+					TotalIssuanceNum::<T>::put(T::DefaultTotalIssuanceNum::get());
+					weight_writes += 1;
+				}
+
+				// Update the block reward, because block generation time reduce to half,
+				// the block reward also needs to reduce to half
+				BlockRewards::<T>::put(BlockRewards::<T>::get() / Balance::from(2_u32));
+				weight_writes += 1;
+				weight_reads += 1;
+
+				let block_number_now = frame_system::Pallet::<T>::block_number();
+				weight_reads += 1;
+
+				// Recalculate the recalculation block number time
+				let recalculate_at = DoRecalculationAt::<T>::get();
+				// Just for the security check, recaulcate_at should be larger than block_number_now
+				if recalculate_at > block_number_now {
+					DoRecalculationAt::<T>::put(
+						block_number_now +
+							(recalculate_at - block_number_now).saturating_mul(2_u32.into()),
+					);
+					weight_writes += 1;
+				}
+				weight_reads += 1;
+
+				let initial_at = DoInitializeAt::<T>::get();
+				// Setup the delay TGE if it had
+				if initial_at > block_number_now {
+					DoInitializeAt::<T>::put(
+						block_number_now +
+							(initial_at - block_number_now).saturating_mul(2_u32.into()),
+					);
+					weight_writes += 1;
+				}
+				weight_reads += 1;
 
 				// Update storage version
 				STORAGE_VERSION.put::<Pallet<T>>();
@@ -57,6 +120,12 @@ mod upgrade {
 			}
 			calculated_weight
 				.saturating_add(T::DbWeight::get().reads_writes(weight_reads, weight_writes))
+		}
+
+		pub fn on_runtime_upgrade() -> Weight {
+			let weight_v1 = Self::migrate_to_v1();
+			let weight_v2 = Self::migrate_to_v2();
+			weight_v1.saturating_add(weight_v2)
 		}
 	}
 }

--- a/pallets/inflation-manager/src/migrations.rs
+++ b/pallets/inflation-manager/src/migrations.rs
@@ -15,6 +15,8 @@ mod upgrade {
 	// This migration will trigger for krest runtime, but not peaq runtime
 	// since peaq will have already been migrated to this storage version with pallet version 0.1.0
 	impl<T: Config> MigrateToV2<T> {
+		// [TODO] Once our krest network's previous runtime ugprade, I think we can remove it
+		// because at that moment, all the storage version should be v1
 		fn migrate_to_v1() -> Weight {
 			let mut weight_writes = 0;
 			let mut weight_reads = 0;

--- a/pallets/inflation-manager/src/tests.rs
+++ b/pallets/inflation-manager/src/tests.rs
@@ -101,13 +101,18 @@ fn sanity_check_storage_migration_for_delayed_tge() {
 		assert_eq!(snapshot.inflation_parameters, expected_inflation_parameters);
 		assert_eq!(
 			snapshot.do_recalculation_at as u64,
-			<TestRuntime as Config>::DoInitializeAt::get()
+			// Because of the Async backing setting
+			1 + (<TestRuntime as Config>::DoInitializeAt::get() - 1) * 2
 		);
 		assert_eq!(snapshot.current_year, 0u128);
+		// We force the migration run
 		assert_eq!(
 			snapshot.block_rewards,
-			<TestRuntime as Config>::BlockRewardBeforeInitialize::get()
+			// Because of the Async backing setting
+			<TestRuntime as Config>::BlockRewardBeforeInitialize::get() / 2
 		);
+		// After delay TGE migration, the DoInitializeAt and DoRecalculationAt should be the same
+		assert_eq!(DoRecalculationAt::<TestRuntime>::get(), DoInitializeAt::<TestRuntime>::get());
 	})
 }
 

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -60,6 +60,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use zenlink_protocol::{AssetBalance, MultiAssetsHandler, PairInfo, ZenlinkMultiAssets};
 
+mod vesting_migration;
 mod weights;
 pub mod xcm_config;
 
@@ -1178,6 +1179,7 @@ pub type Executive = frame_executive::Executive<
 	(
 		cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 		pallet_contracts::Migration<Runtime>,
+		vesting_migration::VestingMigrationToAsyncBacking<Runtime>,
 	),
 >;
 

--- a/runtime/peaq-dev/src/vesting_migration.rs
+++ b/runtime/peaq-dev/src/vesting_migration.rs
@@ -1,0 +1,96 @@
+#[cfg(feature = "try-runtime")]
+use frame_support::pallet_prelude::Decode;
+use frame_support::{
+	traits::{Currency, Get, OnRuntimeUpgrade},
+	weights::Weight,
+	BoundedVec,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+use pallet_vesting::VestingInfo;
+#[cfg(feature = "try-runtime")]
+use parity_scale_codec::Encode;
+use sp_runtime::traits::CheckedDiv;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+use sp_std::vec::Vec;
+type BalanceOf<T> = <<T as pallet_vesting::Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
+type VestingBoundVec<T> = BoundedVec<
+	VestingInfo<BalanceOf<T>, BlockNumberFor<T>>,
+	pallet_vesting::MaxVestingSchedulesGet<T>,
+>;
+
+pub struct VestingMigrationToAsyncBacking<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: frame_system::Config + pallet_vesting::Config> OnRuntimeUpgrade
+	for VestingMigrationToAsyncBacking<T>
+{
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight_writes = 0;
+		let mut weight_reads = 0;
+		pallet_vesting::Vesting::<T>::translate::<VestingBoundVec<T>, _>(
+			|_acc_id, vesting_infos| {
+				weight_reads += 1;
+				weight_writes += 1;
+				let out: Vec<_> = vesting_infos
+					.iter()
+					.map(|s| {
+						let new_per_block =
+							s.per_block().checked_div(&2u32.into()).unwrap_or_default();
+						VestingInfo::<BalanceOf<T>, BlockNumberFor<T>>::new(
+							s.locked(),
+							new_per_block,
+							s.starting_block(),
+						)
+					})
+					.collect();
+				Some(BoundedVec::try_from(out).unwrap())
+			},
+		);
+		log::info!(
+			"Vesting migration for async backing: reads: {}, writes: {}",
+			weight_reads,
+			weight_writes
+		);
+		T::DbWeight::get().reads_writes(weight_reads, weight_writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		let mut old_schedules = Vec::new();
+		for (_acc_id, mut schedules) in pallet_vesting::Vesting::<T>::iter() {
+			if schedules.len() != 0 {
+				old_schedules = schedules.drain(..).collect();
+				break;
+			}
+		}
+		Ok(old_schedules.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let old_schedules =
+			<Vec<VestingInfo<BalanceOf<T>, BlockNumberFor<T>>> as Decode>::decode(&mut &state[..])
+				.expect("pre_upgrade_step provides a valid state; qed");
+
+		let mut new_schedules = Vec::new();
+		for (_acc_id, mut schedules) in pallet_vesting::Vesting::<T>::iter() {
+			if schedules.len() != 0 {
+				new_schedules = schedules.drain(..).collect();
+				break;
+			}
+		}
+		assert_eq!(old_schedules.len(), new_schedules.len());
+		for i in 0..old_schedules.len() {
+			assert_eq!(old_schedules[i].locked(), new_schedules[i].locked());
+			assert_eq!(
+				old_schedules[i].per_block().checked_div(&2u32.into()).unwrap_or_default(),
+				new_schedules[i].per_block()
+			);
+			assert_eq!(old_schedules[i].starting_block(), new_schedules[i].starting_block());
+		}
+
+		Ok(())
+	}
+}

--- a/runtime/peaq/src/lib.rs
+++ b/runtime/peaq/src/lib.rs
@@ -60,6 +60,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use zenlink_protocol::{AssetBalance, MultiAssetsHandler, PairInfo, ZenlinkMultiAssets};
 
+mod vesting_migration;
 mod weights;
 pub mod xcm_config;
 
@@ -1209,6 +1210,7 @@ pub type Executive = frame_executive::Executive<
 	(
 		cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 		pallet_contracts::Migration<Runtime>,
+		vesting_migration::VestingMigrationToAsyncBacking<Runtime>,
 	),
 >;
 

--- a/runtime/peaq/src/vesting_migration.rs
+++ b/runtime/peaq/src/vesting_migration.rs
@@ -1,0 +1,96 @@
+#[cfg(feature = "try-runtime")]
+use frame_support::pallet_prelude::Decode;
+use frame_support::{
+	traits::{Currency, Get, OnRuntimeUpgrade},
+	weights::Weight,
+	BoundedVec,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+use pallet_vesting::VestingInfo;
+#[cfg(feature = "try-runtime")]
+use parity_scale_codec::Encode;
+use sp_runtime::traits::CheckedDiv;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+use sp_std::vec::Vec;
+type BalanceOf<T> = <<T as pallet_vesting::Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
+type VestingBoundVec<T> = BoundedVec<
+	VestingInfo<BalanceOf<T>, BlockNumberFor<T>>,
+	pallet_vesting::MaxVestingSchedulesGet<T>,
+>;
+
+pub struct VestingMigrationToAsyncBacking<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: frame_system::Config + pallet_vesting::Config> OnRuntimeUpgrade
+	for VestingMigrationToAsyncBacking<T>
+{
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight_writes = 0;
+		let mut weight_reads = 0;
+		pallet_vesting::Vesting::<T>::translate::<VestingBoundVec<T>, _>(
+			|_acc_id, vesting_infos| {
+				weight_reads += 1;
+				weight_writes += 1;
+				let out: Vec<_> = vesting_infos
+					.iter()
+					.map(|s| {
+						let new_per_block =
+							s.per_block().checked_div(&2u32.into()).unwrap_or_default();
+						VestingInfo::<BalanceOf<T>, BlockNumberFor<T>>::new(
+							s.locked(),
+							new_per_block,
+							s.starting_block(),
+						)
+					})
+					.collect();
+				Some(BoundedVec::try_from(out).unwrap())
+			},
+		);
+		log::info!(
+			"Vesting migration for async backing: reads: {}, writes: {}",
+			weight_reads,
+			weight_writes
+		);
+		T::DbWeight::get().reads_writes(weight_reads, weight_writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		let mut old_schedules = Vec::new();
+		for (_acc_id, mut schedules) in pallet_vesting::Vesting::<T>::iter() {
+			if schedules.len() != 0 {
+				old_schedules = schedules.drain(..).collect();
+				break;
+			}
+		}
+		Ok(old_schedules.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let old_schedules =
+			<Vec<VestingInfo<BalanceOf<T>, BlockNumberFor<T>>> as Decode>::decode(&mut &state[..])
+				.expect("pre_upgrade_step provides a valid state; qed");
+
+		let mut new_schedules = Vec::new();
+		for (_acc_id, mut schedules) in pallet_vesting::Vesting::<T>::iter() {
+			if schedules.len() != 0 {
+				new_schedules = schedules.drain(..).collect();
+				break;
+			}
+		}
+		assert_eq!(old_schedules.len(), new_schedules.len());
+		for i in 0..old_schedules.len() {
+			assert_eq!(old_schedules[i].locked(), new_schedules[i].locked());
+			assert_eq!(
+				old_schedules[i].per_block().checked_div(&2u32.into()).unwrap_or_default(),
+				new_schedules[i].per_block()
+			);
+			assert_eq!(old_schedules[i].starting_block(), new_schedules[i].starting_block());
+		}
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
1. Update the inflation manager's block reward/recalculation number/inflation number directly
2. Update the vesting directly

Note
1. Even though I think we can remove the V1 in the future, let's do it after the previous Krest runtime upgrade is done
a. Krest --> Run V1 and V2
b. Agung/Peaq -> Run V2
4. On the vesting upgrade, I chose the ugly implementation (copy/paste) because we will remove the migration after this runtime upgrade