### PR TITLE
feat: implement temporary workaround for ubuntu-user-bug

### DIFF
--- a/scripts/Dockerfile.parachain-launch
+++ b/scripts/Dockerfile.parachain-launch
@@ -3,6 +3,10 @@ FROM ubuntu:24.04
 WORKDIR /opt/network
 ADD target/release/peaq-node /usr/local/bin
 
+# This is a temporary workarround to tackle a bug. See:
+# https://bugs.launchpad.net/cloud-images/+bug/2005129
+RUN userdel -r ubuntu
+# Our default behavior:
 RUN useradd -m -u 1000 -U -s /bin/sh -d /peaq-node peaq-node && \
 	mkdir -p /chain-data /peaq-node/.local/share/peaq-node && \
 	chown -R peaq-node:peaq-node /chain-data && \


### PR DESCRIPTION
- See [Ubuntu bug description](https://bugs.launchpad.net/cloud-images/+bug/2005129)
- Default user `ubuntu` in Ubuntu docker images are in conflict with default UID 1000
- Workarround: Remove that default user before adding our own settings