### PR TITLE
fix: add costs for writing to storage and logs

### DIFF
--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -104,6 +104,14 @@ where
 	) -> EvmResult {
 		// NoncesStorage: Blake2_128(16) + contract(20) + Blake2_128(16) + owner(20) + nonce(32)
 		handle.record_db_read::<Runtime>(104)?;
+		// Following two lines are for writing cost.
+		// Implemented similarly to record_db_read() method above.
+		// NoncesStorage / owner(20) + ApprovesStorage / 2 * owner(20) + amount(32)
+		const STORAGE_WRITE_COSTS: u64 = 92;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+		handle.record_external_cost(None, Some(STORAGE_WRITE_COSTS), None)?;
+		// Costs for log3 calls
+		handle.record_log_costs_manual(3, 32)?;
 
 		let owner: H160 = owner.into();
 		let spender: H160 = spender.into();

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -810,7 +810,7 @@ fn permit_valid() {
 						s: rs.s.b32().into(),
 					},
 				)
-				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_cost(1756)
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_APPROVAL,
@@ -1215,7 +1215,7 @@ fn permit_valid_with_metamask_signed_data() {
 						s: s_real.into(),
 					},
 				)
-				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_cost(1756)
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_APPROVAL,


### PR DESCRIPTION
- affects missing gas costs in evm precompile `balances_erc20` method `permit`
- added gas costs for writing to storage and emitting the log
- implementation is aligned to the `record_db_read()` method in `frontier`