### PR TITLE
Meter EVM gas for asset‐ID conversion and enforce storage_growth in X-Tokens precompiles

### DIFF
--- a/precompiles/assets-factory/src/lib.rs
+++ b/precompiles/assets-factory/src/lib.rs
@@ -75,6 +75,7 @@ where
 		_handle: &mut impl PrecompileHandle,
 		id: u64,
 	) -> EvmResult<Address> {
+		_handle.record_db_read::<Runtime>(36)?;
 		let asset_id = id
 			.try_into()
 			.map_err(|_| RevertReason::value_is_too_large("asset id type").in_field("id"))?;

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -113,7 +113,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}
@@ -160,7 +165,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}
@@ -194,7 +204,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}
@@ -240,7 +255,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}
@@ -299,7 +319,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}
@@ -353,7 +378,12 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			SYSTEM_ACCOUNT_SIZE,
+		)?;
 
 		Ok(())
 	}

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -113,7 +113,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}
@@ -160,7 +160,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}
@@ -194,7 +194,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}
@@ -240,7 +240,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}
@@ -299,7 +299,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}
@@ -353,7 +353,7 @@ where
 			dest_weight_limit,
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, SYSTEM_ACCOUNT_SIZE)?;
 
 		Ok(())
 	}


### PR DESCRIPTION
This PR resolves two high-severity audit findings:

Assets-Factory:
	•	Add _handle.record_db_read::<Runtime>(36)?; to convert_asset_id_to_address
	•	Ensures the 36-byte lookup is properly charged gas
	
X-Tokens:
	•	Import pallet_balances::SYSTEM_ACCOUNT_SIZE
	•	Replace every try_dispatch(..., 0) with try_dispatch(..., SYSTEM_ACCOUNT_SIZE)?
	 
audit findings 3 & 4.