### PR TITLE
Enable storage weight reclaim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-pallet-weight-reclaim"
+version = "0.2.0"
+source = "git+https://github.com/peaqnetwork/polkadot-sdk?branch=peaq-polkadot-stable2503-4#0548e837980715584bfdea1fb907c9a6b3186bc2"
+dependencies = [
+ "cumulus-primitives-storage-weight-reclaim",
+ "derive-where",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-trie",
+]
+
+[[package]]
 name = "cumulus-pallet-xcm"
 version = "0.19.1"
 source = "git+https://github.com/peaqnetwork/polkadot-sdk?branch=peaq-polkadot-stable2503-4#0548e837980715584bfdea1fb907c9a6b3186bc2"
@@ -9283,6 +9301,7 @@ dependencies = [
  "address-unification",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
+ "cumulus-pallet-weight-reclaim",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ cumulus-relay-chain-minimal-node = { git = "https://github.com/peaqnetwork/polka
 cumulus-relay-chain-rpc-interface = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4" }
 cumulus-pallet-parachain-system = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }
 cumulus-pallet-aura-ext = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }
+cumulus-pallet-weight-reclaim = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }
 cumulus-pallet-xcm = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }
 cumulus-primitives-core = { git = "https://github.com/peaqnetwork/polkadot-sdk", branch = "peaq-polkadot-stable2503-4", default-features = false }

--- a/runtime/peaq-dev/Cargo.toml
+++ b/runtime/peaq-dev/Cargo.toml
@@ -80,6 +80,7 @@ cumulus-primitives-timestamp = { workspace = true, default-features = false }
 cumulus-primitives-aura = { workspace = true, default-features = false }
 cumulus-pallet-parachain-system = { workspace = true, default-features = false }
 cumulus-pallet-aura-ext = { workspace = true, default-features = false }
+cumulus-pallet-weight-reclaim = { workspace = true, default-features = false }
 parachain-info = { workspace = true, default-features = false }
 parachains-common = { workspace = true, default-features = false }
 polkadot-parachain = { workspace = true, default-features = false }

--- a/runtime/peaq-dev/src/lib.rs
+++ b/runtime/peaq-dev/src/lib.rs
@@ -35,7 +35,7 @@ use peaq_pallet_rbac::{
 };
 use peaq_pallet_storage::traits::Storage;
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
-use sp_runtime::{traits::IdentityLookup, generic::Preamble};
+use sp_runtime::{generic::Preamble, traits::IdentityLookup};
 
 use frame_support::traits::{
 	tokens::{fungible::HoldConsideration, PayFromAccount, UnityAssetBalanceConversion},
@@ -57,7 +57,7 @@ use sp_runtime::{
 	},
 	ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
-use sp_std::{marker::PhantomData, prelude::*, vec, vec::Vec, borrow::Cow};
+use sp_std::{borrow::Cow, marker::PhantomData, prelude::*, vec, vec::Vec};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -651,7 +651,8 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
 	{
 		if let Some(author_index) = F::find_author(digests) {
-			let authority_id = pallet_aura::Authorities::<Runtime>::get()[author_index as usize].clone();
+			let authority_id =
+				pallet_aura::Authorities::<Runtime>::get()[author_index as usize].clone();
 			let encoded = authority_id.encode();
 			let bytes: [u8; 32] =
 				encoded.try_into().expect("Encoded authority_id should be exactly 32 bytes");
@@ -739,7 +740,8 @@ parameter_types! {
 
 impl pallet_ethereum::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type StateRoot = pallet_ethereum::IntermediateStateRoot<<Self as frame_system::Config>::Version>;
+	type StateRoot =
+		pallet_ethereum::IntermediateStateRoot<<Self as frame_system::Config>::Version>;
 	type PostLogContent = PostBlockAndTxnHashes;
 	type ExtraDataLength = ConstU32<30>;
 }
@@ -1184,17 +1186,21 @@ construct_runtime!(
 );
 
 /// The SignedExtension to the basic transaction logic.
-pub type SignedExtra = (
-	frame_system::CheckNonZeroSender<Runtime>,
-	frame_system::CheckSpecVersion<Runtime>,
-	frame_system::CheckTxVersion<Runtime>,
-	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
-	frame_system::CheckNonce<Runtime>,
-	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
-);
+pub type SignedExtra = cumulus_pallet_weight_reclaim::StorageWeightReclaim<
+	Runtime,
+	(
+		frame_system::CheckNonZeroSender<Runtime>,
+		frame_system::CheckSpecVersion<Runtime>,
+		frame_system::CheckTxVersion<Runtime>,
+		frame_system::CheckGenesis<Runtime>,
+		frame_system::CheckEra<Runtime>,
+		frame_system::CheckNonce<Runtime>,
+		frame_system::CheckWeight<Runtime>,
+		pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+		frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
+	),
+>;
+
 type EventRecord = frame_system::EventRecord<
 	<Runtime as frame_system::Config>::RuntimeEvent,
 	<Runtime as frame_system::Config>::Hash,
@@ -1464,7 +1470,7 @@ impl_runtime_apis! {
 			ParachainSystem::core_selector()
 		}
 	}
-	
+
 	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
 		fn account_nonce(account: AccountId) -> Nonce {
 			System::account_nonce(account)
@@ -2217,6 +2223,10 @@ cumulus_pallet_parachain_system::register_validate_block! {
 parameter_types! {
 	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
 		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE);
+}
+
+impl cumulus_pallet_weight_reclaim::Config for Runtime {
+	type WeightInfo = ();
 }
 
 impl pallet_vesting::Config for Runtime {


### PR DESCRIPTION
This change will fix the issues observed in https://github.com/paritytech/polkadot-sdk/issues/9188 . Storage weight reclaim makes the runtime use the measured proof size instead of the estimated worst case scenario.

This should be applied to any other branches. Without it, you are not able to maximize TPS even of a single core. 