### PR TITLE
Enable rpc-binary-search-estimate for accurate gas estimates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ parachains-common = { git = "https://github.com/peaqnetwork/polkadot-sdk", branc
 fc-consensus = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
 fc-db = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
 fc-mapping-sync = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
-fc-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
+fc-rpc = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2", default-features = false, features = ["txpool", "rpc-binary-search-estimate"] }
 fc-rpc-core = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
 fc-api = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }
 fp-consensus = { git = "https://github.com/peaqnetwork/frontier", branch = "peaq-polkadot-v1.7.2" }

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -33,7 +33,7 @@ ethereum = { workspace = true, default-features = false, features = [ "with-code
 ethereum-types = { workspace = true, default-features = true }
 fc-consensus = { workspace = true, default-features = true }
 fc-db = { workspace = true, default-features = true }
-fc-rpc = { workspace = true, default-features = true, features = [ "rpc-binary-search-estimate" ] }
+fc-rpc = { workspace = true }
 fp-rpc = { workspace = true, default-features = true }
 fc-storage = { workspace = true, default-features = true }
 fc-api = { workspace = true }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -38,7 +38,7 @@ sp-transaction-pool = { workspace = true, default-features = true }
 
 # Frontier
 fc-consensus = { workspace = true, default-features = true }
-fc-rpc = { workspace = true, default-features = true, features = [ "rpc-binary-search-estimate" ] }
-fc-rpc-core = { workspace = true, default-features = true }
+fc-rpc = { workspace = true }
+fc-rpc-core = { workspace = true }
 fp-rpc = { workspace = true, default-features = true }
 fc-storage = { workspace = true, default-features = true }


### PR DESCRIPTION
# Enable `rpc-binary-search-estimate` for accurate gas estimates

### Why
Front-end wallets were hitting _out-of-gas_ errors because Frontier’s default estimator reports only the gas from a single simulation.  
Turning on `rpc-binary-search-estimate` makes the node do a binary search and applies the 63/64 EIP-150 cushion, bringing its behaviour in line with Geth.

**Success checks**

cargo check ✅

cargo build --release  ✅

---

## What changed

| File / Section | Change |
|----------------|--------|
| **Cargo.toml** (workspace root) | Added:<br/>`default-features = false`<br/>`features = ["txpool", "rpc-binary-search-estimate"]` to the `fc-rpc` dependency |
| `client/rpc/debug`<br/>`client/rpc/trace` | Dropped local `fc-rpc` overrides – they now inherit the workspace setting |
| _Runtime_ | **None** – no runtime code touched |

```toml
# Frontier
- fc-rpc = { git = "...frontier", branch = "peaq-polkadot-v1.7.2" }
+ fc-rpc = { git = "...frontier", branch = "peaq-polkadot-v1.7.2", default-features = false, features = ["txpool", "rpc-binary-search-estimate"] }

