### PR TITLE
feat:enable rpc-binary-search-estimate

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -69,7 +69,7 @@ hex-literal = { workspace = true, default-features = true }
 fc-consensus = { workspace = true, default-features = true }
 fc-db = { workspace = true, default-features = true }
 fc-mapping-sync = { workspace = true, default-features = true }
-fc-rpc = { workspace = true, default-features = true }
+fc-rpc = { workspace = true, default-features = true, features = [ "rpc-binary-search-estimate" ] }
 fc-rpc-core = { workspace = true, default-features = true }
 fc-api = { workspace = true, default-features = true }
 fp-consensus = { workspace = true, default-features = true }


### PR DESCRIPTION
### feat: Enable RPC binary search estimate

-   This change enables the rpc-binary-search-estimate feature on the fc-rpc dependency within the node's Cargo.toml. This activates binary search-based gas estimation for RPC calls, which can provide more accurate results.