### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/ManualPublish_and_Deployment.yml
+++ b/.github/workflows/ManualPublish_and_Deployment.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Trigger Build Docker Image workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Compile node
       uses: addnab/docker-run-action@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set-Up
         run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       
@@ -33,7 +33,7 @@ jobs:
     
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       
       - name: Fix permissions
         run: |

--- a/.github/workflows/preview-upgrade.yml
+++ b/.github/workflows/preview-upgrade.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Increment spec_version
       id: version_update
       run: |

--- a/.github/workflows/publishondhr.yml
+++ b/.github/workflows/publishondhr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: "Free Disk Space (insightsengineering/disk-space-reclaimer)"
         uses: insightsengineering/disk-space-reclaimer@v1.1.0
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/publishondockerhub.yml
+++ b/.github/workflows/publishondockerhub.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Free Disk Space (insightsengineering/disk-space-reclaimer)"
         uses: insightsengineering/disk-space-reclaimer@v1.1.0
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0