### PR TITLE
remove -Dwarnings from pr-check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -60,4 +60,4 @@ jobs:
             
       - name: Run clippy
         run: |
-          cargo clippy --release --features on-chain-release-build -- -Dwarnings
+          cargo clippy --release --features on-chain-release-build,try-runtime,runtime-benchmarks,evm-tracing


### PR DESCRIPTION
- Removed -Dwarnings flag as workflow fails due to false positives
- Updated workflow to check all critical features, ensuring failure if a feature fails to build