### PR TITLE
docs: add EVM tracing wasm overrides guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ subcommands:
 ./target/release/peaq-node -h
 ```
 
+### EVM Tracing
+
+Running a tracing node (`debug` / `trace` RPC support) requires WASM runtime overrides, published on the [evm-tracing-wasm-overrides release](https://github.com/peaqnetwork/peaq-network-node/releases/tag/evm-tracing-wasm-overrides). See [docs/evm-tracing.md](docs/evm-tracing.md) for setup.
+
 ## Run
 
 The provided `cargo run` command will launch a temporary node and its state will be discarded after

--- a/docs/evm-tracing.md
+++ b/docs/evm-tracing.md
@@ -23,6 +23,17 @@ Or with curl, fetch individual files:
 curl -LO https://github.com/peaqnetwork/peaq-network-node/releases/download/evm-tracing-wasm-overrides/peaq_runtime.compact.compressed.wasm.peaq.v0.0.112-evm.wasm
 ```
 
+## Verify
+
+The release includes a `SHA256SUMS` manifest covering every asset. After downloading, verify from inside the download folder:
+
+```bash
+curl -LO https://github.com/peaqnetwork/peaq-network-node/releases/download/evm-tracing-wasm-overrides/SHA256SUMS
+sha256sum --check --ignore-missing SHA256SUMS   # macOS: shasum -a 256 -c SHA256SUMS
+```
+
+Every file you downloaded should report `OK`.
+
 ## Run
 
 Build or use a node binary with the `evm-tracing` feature, then start it with:

--- a/docs/evm-tracing.md
+++ b/docs/evm-tracing.md
@@ -1,0 +1,42 @@
+# EVM tracing node: WASM runtime overrides
+
+Running a peaq node with EVM tracing enabled (`debug` / `trace` RPC methods) requires runtime overrides: historical runtimes recompiled with the `evm-tracing` feature. Without them, tracing calls fail on any block produced by a runtime version that predates tracing support.
+
+All overrides for peaq mainnet are published as assets on a rolling GitHub release:
+
+**https://github.com/peaqnetwork/peaq-network-node/releases/tag/evm-tracing-wasm-overrides**
+
+The release also includes `peaq-raw.json`, the peaq mainnet raw chain spec.
+
+## Download
+
+With the GitHub CLI:
+
+```bash
+mkdir -p wasm-overrides
+gh release download evm-tracing-wasm-overrides -R peaqnetwork/peaq-network-node -p '*.wasm' -D wasm-overrides
+```
+
+Or with curl, fetch individual files:
+
+```bash
+curl -LO https://github.com/peaqnetwork/peaq-network-node/releases/download/evm-tracing-wasm-overrides/peaq_runtime.compact.compressed.wasm.peaq.v0.0.112-evm.wasm
+```
+
+## Run
+
+Build or use a node binary with the `evm-tracing` feature, then start it with:
+
+```bash
+peaq-node \
+  --chain peaq-raw.json \
+  --ethapi=debug,trace,txpool \
+  --wasm-runtime-overrides=wasm-overrides \
+  ... # your usual flags
+```
+
+The node selects the correct override per block by reading the `spec_version` embedded in each wasm file, so the whole folder can be passed as-is. Filenames are informational only.
+
+## Updating
+
+When a new runtime version ships, the matching tracing override is added to the same release, so the link above always has the full set.

--- a/docs/evm-tracing.md
+++ b/docs/evm-tracing.md
@@ -35,7 +35,7 @@ peaq-node \
   ... # your usual flags
 ```
 
-The node selects the correct override per block by reading the `spec_version` embedded in each wasm file, so the whole folder can be passed as-is. Filenames are informational only.
+The node selects the correct override per block by reading the `spec_version` embedded in each wasm file, so the whole folder can be passed as-is. Filenames are informational only, with one exception: every override file must keep the `.wasm` suffix. The node only picks up files ending in `.wasm`, so anything renamed without it is silently ignored.
 
 ## Updating
 


### PR DESCRIPTION
Adds a short guide pointing tracing-node operators at the new rolling release that hosts all peaq mainnet wasm runtime overrides:

https://github.com/peaqnetwork/peaq-network-node/releases/tag/evm-tracing-wasm-overrides

This replaces the shared Google Drive folder as the distribution channel. The release holds all 17 override wasm files (v0.0.2 through v0.0.112) plus the raw mainnet chain spec, and new overrides get appended to the same tag as runtimes ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)