### PR TITLE
fix(docker): resolve compose file from repository root

### DIFF
--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -4,7 +4,8 @@ set -e
 
 echo "*** Start PEAQ Network Node ***"
 
-cd $(dirname ${BASH_SOURCE[0]})/..
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+compose_file="${repository_root}/scripts/docker-compose.yml"
 
-docker-compose down --remove-orphans
-docker-compose run --rm --service-ports dev $@
+docker-compose --project-directory "${repository_root}" -f "${compose_file}" down --remove-orphans
+docker-compose --project-directory "${repository_root}" -f "${compose_file}" run --rm --service-ports dev "$@"


### PR DESCRIPTION
## Summary

- resolve the repository root from the script location
- pass the Compose file and project directory explicitly
- preserve forwarded command arguments

## Problem

While using the documented Docker workflow, I found that `./scripts/docker_run.sh cargo check` exits immediately with:

```text
no configuration file provided: not found
```

The helper changes to the repository root, while the Compose file is stored at `scripts/docker-compose.yml`. Compose therefore cannot discover the project configuration.

## Testing

- `bash -n scripts/docker_run.sh`
- `docker-compose --project-directory "$PWD" -f "$PWD/scripts/docker-compose.yml" config`
- `./scripts/docker_run.sh cargo --version` → `cargo 1.82.0 (8f40fc59f 2024-08-21)`
